### PR TITLE
Auto-detect series in metadata support

### DIFF
--- a/push-and-publish-multi-series
+++ b/push-and-publish-multi-series
@@ -16,8 +16,18 @@ if [ -z "$charm" ] || [ -z "$branch" ]; then
     exit 1
 fi
 
+# Override charm dir when driven by Jenkins.
+# Otherwise, use cmd param provided.
+if [ -n "$WORKSPACE" ]; then
+    # Driven by Jenkins.
+    charm_dir="$WORKSPACE/$charm"
+else
+    # Expect a local checkout in the current dir.
+    charm_dir="$charm"
+fi
+
 # Locate metadata.yaml for charm
-metadata=$(find . -name "metadata.yaml")
+metadata=$(find $charm_dir -name "metadata.yaml")
 
 # Auto-detect a series in metadata charm
 if grep -q "^series:.*" $metadata; then

--- a/push-and-publish-multi-series
+++ b/push-and-publish-multi-series
@@ -16,32 +16,34 @@ if [ -z "$charm" ] || [ -z "$branch" ]; then
     exit 1
 fi
 
-# Push and publish for all relevant series of the charms which
-# use the legacy simulated multiple series approach of pushing
-# to individual cs series spaces.
-for this_series in $series; do
-    charms=$(cat $this_series.txt)
-    for charm_check in $charms; do
-        if [ "$charm_check" == "$charm" ]; then
-            found=true
-            # Source it to preserve BUILT_ASSET_DIR, etc.
-            . push-and-publish $charm $this_series $branch
-        fi
-    done
-done
+# Locate metadata.yaml for charm
+metadata=$(find . -name "metadata.yaml")
 
-# Push and publish for proper multi-series charms, where
-# series is declared in the metadata.yaml for cs: to interpret.
-if [ -z "$found" ]; then
-    charms=$(cat multi.txt)
-    for charm_check in $charms; do
-        if [ "$charm_check" == "$charm" ]; then
-            found=true
-            echo " . Handling $charm as a proper multi-series charm"
-            # Source it to preserve BUILT_ASSET_DIR, etc.
-            . push-and-publish $charm multi $branch
-        fi
+# Auto-detect a series in metadata charm
+if grep -q "^series:.*" $metadata; then
+    # Push and publish for proper multi-series charms, where
+    # series is declared in the metadata.yaml for cs: to interpret.
+   . push-and-publish $charm multi $branch
+else
+    # Push and publish for all relevant series of the charms which
+    # use the legacy simulated multiple series approach of pushing
+    # to individual cs series spaces.
+    for this_series in $series; do
+        charms=$(cat $this_series.txt)
+        for charm_check in $charms; do
+            if [ "$charm_check" == "$charm" ]; then
+                found=true
+                # Source it to preserve BUILT_ASSET_DIR, etc.
+                . push-and-publish $charm $this_series $branch
+            fi
+        done
     done
+
+    # Fatal if not found
+    if [ -z "$found" ]; then
+        echo "$charm not found in defined lists.  No action taken."
+        exit 1
+    fi
 fi
 
 echo " . Charm store refs published:"
@@ -51,10 +53,4 @@ if [[ -n "$WORKSPACE" ]]; then
   mv -v $cs_refs_published $WORKSPACE/cs_refs_published.txt
 else
   rm -fv $cs_refs_published
-fi
-
-# Fatal if not found
-if [ -z "$found" ]; then
-    echo "$charm not found in defined lists.  No action taken."
-    exit 1
 fi


### PR DESCRIPTION
In preparation for the switch to series in metadata across
all OpenStack charms, update the charm store pusher to auto
detect series in metadata, and publish charms using the multi
target, allowing the charm store to figure out which series
a charm should support.

If detected, this is preferred over any configuration files
in release-tools.