### PR TITLE
Add carriage return to defaultbranch in .gitreview

### DIFF
--- a/stable-branch-updates
+++ b/stable-branch-updates
@@ -14,7 +14,7 @@ fi
 git checkout -b ${release}-updates origin/stable/${release}
 
 grep -q defaultbranch .gitreview || {
-    echo "defaultbranch=stable/$release" >> .gitreview
+    echo -e "\ndefaultbranch=stable/$release" >> .gitreview
     git add .gitreview
 }
 


### PR DESCRIPTION
Some .gitreview files do not have an EOF/newline at the end of the last line causing a problem with the addition here on line 17