### PR TITLE
Enable some off-by-default checks

### DIFF
--- a/global/classic-charms/tox.ini
+++ b/global/classic-charms/tox.ini
@@ -83,3 +83,4 @@ commands =
 [flake8]
 ignore = E402,E226
 exclude = */charmhelpers
+enable-extensions = H106,H203

--- a/global/source-charms/tox.ini
+++ b/global/source-charms/tox.ini
@@ -53,3 +53,4 @@ commands = {posargs}
 [flake8]
 # E402 ignore necessary for path append before sys module import in actions
 ignore = E402
+enable-extensions = H106,H203


### PR DESCRIPTION
Some of the available checks are disabled by default, like:

 [H106] Don’t put vim configuration in source files
 [H203] Use assertIs(Not)None to check for None