### PR TITLE
Override the vault bug link

### DIFF
--- a/bug-link-overrides.txt
+++ b/bug-link-overrides.txt
@@ -1,1 +1,1 @@
-
+vault|https://bugs.launchpad.net/vault-charm/+filebug


### PR DESCRIPTION
The vault bug link incorrectly points to
https://bugs.launchpad.net/charm-vault/+filebug
when it should be
https://bugs.launchpad.net/vault-charm/+filebug

Update the bug-link-overrides for vault.