### PR TITLE
Make an exponential backoff retry function

### DIFF
--- a/build-charm
+++ b/build-charm
@@ -4,6 +4,8 @@
 # Some layer components may be blocked by egress firewalls. It may
 # be necessary to use an http_proxy (set env var beforehand if so).
 
+. helpers.sh
+
 charm_dir="$1"
 charm_name="$2"
 usage="usage: build-charm <charm checkout dir> <charm name>
@@ -53,13 +55,7 @@ if grep "^\[testenv:build\]$" $charm_dir/tox.ini &> /dev/null; then
   DIR="$(pwd)"
   cd $charm_dir
   # Let us retry a couple of times in case of a transient failure fetching bits
-  n=0
-  until [ $n -ge 3 ]
-  do
-    tox -e build && break
-    n=$[$n+1]
-    sleep 3
-  done
+  retry tox -e build
   cd $DIR
 else
   echo " . No tox build target in $charm_dir ($charm_name). The charm should support 'tox -e build'!"

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+# Helpers for functionality that can be shared within release-tools
+
+function retry() {
+  n=0
+  base_delay=3
+  delay=$base_delay
+  until [ $n -ge 3 ]
+  do
+    $@ && break
+    n=$[$n+1]
+    echo "Going to try again in ${delay} seconds"
+    sleep $delay
+    delay=$(( $base_delay**($n+1) ))
+  done
+}


### PR DESCRIPTION
This function is added to a new helpers.sh file
that can be included in all release-tools scripts
in case we need exponential backoff elsewhere