### PR TITLE
Add W503 to ignores for flake8

### DIFF
--- a/global/classic-amulet/tox.ini
+++ b/global/classic-amulet/tox.ini
@@ -117,5 +117,5 @@ commands =
     bundletester -vl DEBUG -r json -o func-results.json --test-pattern "dev-*" --no-destroy
 
 [flake8]
-ignore = E402,E226
+ignore = E402,E226,W503
 exclude = */charmhelpers

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -111,5 +111,5 @@ commands =
     functest-run-suite --keep-model --bundle {posargs}
 
 [flake8]
-ignore = E402,E226
+ignore = E402,E226,W503
 exclude = */charmhelpers

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -89,4 +89,4 @@ commands = {posargs}
 
 [flake8]
 # E402 ignore necessary for path append before sys module import in actions
-ignore = E402,W504
+ignore = E402,W503


### PR DESCRIPTION
The current PEP8/black coding standard [1] is to place binary operators
on the continuation line at the beginning.  Although charms are not
strictly black compliant, this is a useful direction to head in.

[1]: https://github.com/psf/black/blob/9b484d1bcc2e15dcd5544cddab729c76b4d1d2e9/README.md#line-length