### PR TITLE
Add mysql-innodb-cluster 0-bytes resource

### DIFF
--- a/resources.txt
+++ b/resources.txt
@@ -21,6 +21,7 @@ octavia-diskimage-retrofit:master:octavia-diskimage-retrofit:octavia-diskimage-r
 octavia-diskimage-retrofit:stable/20.02:snapd:snapd-0
 octavia-diskimage-retrofit:stable/20.02:core18:core18-0
 octavia-diskimage-retrofit:stable/20.02:octavia-diskimage-retrofit:octavia-diskimage-retrofit-0
+mysql-innodb-cluster:master:mysql-shell:mysql-shell-0
 nova-cloud-controller:master:policyd-override:policyd-override-0
 cinder:master:policyd-override:policyd-override-0
 keystone:master:policyd-override:policyd-override-0


### PR DESCRIPTION
Recently, the mysql-innodb-cluster charm has added a resource for the
mysql-shell resource (a snap).  In order for the pusher to work, an
entry is required for the master branch.  On release, a stable branch
entry will also be needed.