### PR TITLE
Use the cs:~openstack-charmers charms for stable

### DIFF
--- a/stable-branch-updates
+++ b/stable-branch-updates
@@ -33,17 +33,18 @@ fi
 if [ -d src/tests/bundles ]; then
     echo "Updating zaza tests to refer to stable branches src"
     for filename in $(find src/tests/bundles | grep yaml); do
-        sed -i 's#cs:~openstack-charmers-next/#cs:#g' $filename
+        sed -i 's#cs:~openstack-charmers-next/#cs:~openstack-charmers/#g' $filename
         # Quagga actually needs to be in ~openstack-charmers-next
-        sed -i 's#cs:quagga#cs:~openstack-charmers-next/quagga#g' $filename
+        sed -i 's#cs:~openstack-charmers/quagga#cs:~openstack-charmers-next/quagga#g' $filename
     done
+    echo "git add ."
     git add src/tests/bundles
 fi
 
 if [ -d tests/bundles ]; then
     echo "Updating zaza tests to refer to stable branches src"
     for filename in $(find tests/bundles | grep yaml); do
-        sed -i 's#cs:~openstack-charmers-next/#cs:#g' $filename
+        sed -i 's#cs:~openstack-charmers-next/#cs:~openstack-charmers/#g' $filename
     done
     git add tests/bundles
 fi


### PR DESCRIPTION
When using the cs:$CHARM we run into promulgated vs unpromulgated
problems for testing. By using the cs:~openstack-charmers/$CHARM we
avoid this problem.