### PR TITLE
Use opendev and enable repo link overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ Scripts used by OpenStack Charms automated and manual release processes for Char
 ## Files
 File | Purpose / Note
 :--- | :---
+```bug-link-overrides```    | A list of exceptions and overrides for charm bug trackers that deviate from the usual URL structure.
 ```build-charm```           | Build src charms, enforce certain file and directory expectations.  Used by OSCI during tests.  Called by ```push-and-release``` as needed.
 ```charms.txt```            | The master list of all OpenStack charms which are subject to pushing/releasing via the git, gerrit, charm store flow.
+```check-repo-links```      | Check the repo links
 ```create-stable-branch```  | Create stable branches in charm repos.  Called by ```release-charms```, also used by humans during release processes.
 ```generate-repo-info```    | Used by OSCI to generate indentifying information about the checked out git repo and inject it into the charm dir before pushing and releasing.
 ```get-charms```            | Clones charm repos and checks out the provided branch.
 ```push-and-release```      | Used by OSCI automation to build, push and release charms after changes are merged and changed at the github repos.
 ```release-stable-charms``` | Do a new STABLE RELEASE from MASTER for all charms.
+```repo-link-overrides```   | A list of exceptions and overrides for charm repos that deviate from the usual URL structure.
 ```source-charms.txt```     | Master list of 'source charms,' used by ```update-tox-files```.
 ```stable-branch-updates``` | Post-Release Repo Tasks: Flip stable charm-helpers and Amulet bits;  Update .gitreview with new stable branch name. Called by ```update-stable-charms```.
 ```update-stable-charms```  | Applies stable-branch-updates to all charms.

--- a/check-repo-links
+++ b/check-repo-links
@@ -1,0 +1,26 @@
+#!/bin/bash -ue
+# Check repo links
+
+DISPOSITION=0
+for charm in $(cat charms.txt); do
+
+  # Handle repo url overrides if present
+  if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
+     REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+  else
+     REPO_URL="https://opendev.org/openstack/charm-${charm}"
+  fi
+
+  HTTP_CODE=$(curl --head -s -o /dev/null -w "%{http_code}" ${REPO_URL})
+
+  # Fail on missing bug links
+  if [[ $HTTP_CODE =~ ^(200|303)$ ]]; then
+      FMT="\e[0m  "
+  else
+      FMT="\e[31m**"
+      DISPOSITION=1
+  fi
+
+  echo -e "${FMT}$HTTP_CODE    $REPO_URL"
+done
+exit $DISPOSITION

--- a/get-charms
+++ b/get-charms
@@ -4,7 +4,6 @@
 branch="$1"
 all_charms="$(cat charms.txt)"
 usage="usage: get-charms <master||stable/nn.nn>"
-base_url="https://opendev.org/openstack/charm-"
 
 # Optionally useful for local and/or offline iterations:
 # base_url="$HOME/git/release-tools.alt/"
@@ -15,7 +14,15 @@ fi
 
 for charm in $all_charms; do
     [ -d $charm ] && rm -Rf $charm
-    git clone $base_url$charm $charm
+
+    # Handle repo url overrides if present
+    if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
+       REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+    else
+       REPO_URL="https://opendev.org/openstack/charm-${charm}"
+    fi
+
+    git clone $REPO_URL $charm
     (cd $charm; git checkout $branch)
 done
 

--- a/get-charms
+++ b/get-charms
@@ -4,7 +4,7 @@
 branch="$1"
 all_charms="$(cat charms.txt)"
 usage="usage: get-charms <master||stable/nn.nn>"
-base_url="https://github.com/openstack/charm-"
+base_url="https://opendev.org/openstack/charm-"
 
 # Optionally useful for local and/or offline iterations:
 # base_url="$HOME/git/release-tools.alt/"

--- a/push-and-release
+++ b/push-and-release
@@ -164,8 +164,15 @@ else
    BUGS_URL="https://bugs.launchpad.net/charm-${charm}/+filebug"
 fi
 
+# Handle repo url overrides if present
+if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
+   REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+else
+   REPO_URL="https://opendev.org/openstack/charm-${charm}"
+fi
+
 retry_command charm set $charm_store_url bugs-url=$BUGS_URL \
-    homepage=https://opendev.org/openstack/charm-$charm
+    homepage=$REPO_URL
 
 echo " . Charm store refs released:"
 cat $cs_refs_released

--- a/push-and-release
+++ b/push-and-release
@@ -165,7 +165,7 @@ else
 fi
 
 retry_command charm set $charm_store_url bugs-url=$BUGS_URL \
-    homepage=https://github.com/openstack/charm-$charm
+    homepage=https://opendev.org/openstack/charm-$charm
 
 echo " . Charm store refs released:"
 cat $cs_refs_released

--- a/release-stable-charms
+++ b/release-stable-charms
@@ -15,7 +15,7 @@ fi
 
 for charm in $charms; do
     [ -d $charm ] && rm -Rf $charm
-    git clone https://github.com/openstack/charm-$charm $charm
+    git clone https://opendev.org/openstack/charm-$charm $charm
     (
         cd $charm
         echo "Adding gerrit remote"

--- a/release-stable-charms
+++ b/release-stable-charms
@@ -15,7 +15,15 @@ fi
 
 for charm in $charms; do
     [ -d $charm ] && rm -Rf $charm
-    git clone https://opendev.org/openstack/charm-$charm $charm
+
+    # Handle repo url overrides if present
+    if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
+       REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+    else
+       REPO_URL="https://opendev.org/openstack/charm-${charm}"
+    fi
+
+    git clone $REPO_URL $charm
     (
         cd $charm
         echo "Adding gerrit remote"

--- a/repo-link-overrides.txt
+++ b/repo-link-overrides.txt
@@ -1,0 +1,3 @@
+ovn-central|https://opendev.org/x/charm-ovn-central
+ovn-chassis|https://opendev.org/x/charm-ovn-chassis
+ovn-dedicated-chassis|https://opendev.org/x/charm-ovn-dedicated-chassis

--- a/update-stable-charms
+++ b/update-stable-charms
@@ -15,7 +15,15 @@ fi
 
 for charm in $charms; do
     [ -d $charm ] && rm -Rf $charm
-    git clone https://opendev.org/openstack/charm-$charm $charm
+
+    # Handle repo url overrides if present
+    if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
+       REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+    else
+       REPO_URL="https://opendev.org/openstack/charm-${charm}"
+    fi
+
+    git clone $REPO_URL $charm
     (
         cd $charm
         $basedir/stable-branch-updates $release

--- a/update-stable-charms
+++ b/update-stable-charms
@@ -15,7 +15,7 @@ fi
 
 for charm in $charms; do
     [ -d $charm ] && rm -Rf $charm
-    git clone https://github.com/openstack/charm-$charm $charm
+    git clone https://opendev.org/openstack/charm-$charm $charm
     (
         cd $charm
         $basedir/stable-branch-updates $release


### PR DESCRIPTION
This shifts to use opendev.org instead of github.com, and adds a repo link check tool, and allows /x/ or /openstack/ urls without having to do local hacks.