### PR TITLE
20.05 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ ovn-central
 ovn-chassis
 ovn-dedicated-chassis
 placement
+trilio-data-mover
+trilio-dm-api
+trilio-horizon-plugin
+trilio-wlm

--- a/commit-message-update-branches.txt
+++ b/commit-message-update-branches.txt
@@ -2,6 +2,8 @@ Updates for stable branch creation
 
 Set default branch for git review/gerrit.
 
-Switch amulet tests to stable.
+Switch tests to stable.
 
 Switch to using stable charm-helpers branch.
+
+Switch to using stable charm.openstack branch.

--- a/release-stable-charms
+++ b/release-stable-charms
@@ -19,15 +19,17 @@ for charm in $charms; do
     # Handle repo url overrides if present
     if grep "^$charm|" repo-link-overrides.txt > /dev/null; then
        REPO_URL=$(grep "^$charm|" repo-link-overrides.txt | cut -f 2 -d "|")
+       TLP=$(grep "^$charm|" repo-link-overrides.txt | cut -f 4 -d "/")
     else
        REPO_URL="https://opendev.org/openstack/charm-${charm}"
+       TLP=openstack
     fi
 
     git clone $REPO_URL $charm
     (
         cd $charm
         echo "Adding gerrit remote"
-        git remote add gerrit ssh://${username}@review.openstack.org:29418/openstack/charm-${charm}.git
+        git remote add gerrit ssh://${username}@review.openstack.org:29418/${TLP}/charm-${charm}.git
         echo "Creating stable branch for release $release"
         $basedir/create-stable-branch $release
     )

--- a/stable-branch-updates
+++ b/stable-branch-updates
@@ -64,8 +64,9 @@ if [ -f src/layer.yaml ]; then
     set +e
     grep -q layer:openstack src/layer.yaml && {
         grep -q charms.openstack.git@stable src/wheelhouse.txt 2>/dev/null || {
-	    echo "Updating charm wheelhouse, with stable 'charms.openstack'"
+	    echo "Updating charm wheelhouse, with stable 'charms.openstack' and 'charmhelpers'"
             echo -e "\ngit+https://opendev.org/openstack/charms.openstack.git@stable/$release#egg=charms.openstack" >> src/wheelhouse.txt
+            echo -e "\ngit+https://github.com/juju/charm-helpers.git@stable/$release#egg=charmhelpers" >> src/wheelhouse.txt
 	    set -e
 	    git add src/wheelhouse.txt
         }

--- a/stable-branch-updates
+++ b/stable-branch-updates
@@ -32,7 +32,7 @@ fi
 
 if [ -d src/tests/bundles ]; then
     echo "Updating zaza tests to refer to stable branches src"
-    for filename in $(find src/tests/bundles | grep yaml); do
+    for filename in $(find src/tests/bundles -type f | grep yaml); do
         sed -i 's#cs:~openstack-charmers-next/#cs:~openstack-charmers/#g' $filename
         # Quagga actually needs to be in ~openstack-charmers-next
         sed -i 's#cs:~openstack-charmers/quagga#cs:~openstack-charmers-next/quagga#g' $filename
@@ -43,7 +43,7 @@ fi
 
 if [ -d tests/bundles ]; then
     echo "Updating zaza tests to refer to stable branches src"
-    for filename in $(find tests/bundles | grep yaml); do
+    for filename in $(find tests/bundles -type f | grep yaml); do
         sed -i 's#cs:~openstack-charmers-next/#cs:~openstack-charmers/#g' $filename
     done
     git add tests/bundles


### PR DESCRIPTION
    Add stable charm-helpers to reactive wheelhouse
    Use top level project name for non-openstack charms in gerrit
