### PR TITLE
Add a simple list-revisions and dates helper

### DIFF
--- a/list-revisions-in-charmstore.py
+++ b/list-revisions-in-charmstore.py
@@ -1,0 +1,57 @@
+from typing import List, Tuple
+import sys
+
+import theblues.charmstore
+import charmstore
+
+name = "nova-compute"
+
+
+def usage():
+    print("usage: {} <charm-name>".format(sys.argv[0]))
+
+
+def parse_args() -> str:
+    if len(sys.argv) < 2:
+        usage()
+        sys.exit(1)
+    charm = sys.argv[1]
+    return charm
+
+
+def get_revisions(name: str) -> List[Tuple[str, str]]:
+    charm = charmstore.CharmStore().search(name)[0]
+    latest = charm.revision
+    print("{} revisions for charm: {}".format(latest, name))
+
+    cs = theblues.charmstore.CharmStore()
+
+    results = []
+    for a in range(1, int(latest)):
+        print(".", end="", flush=True)
+        try:
+            results.append(("{}/{}".format(name, a),
+                            (cs.entity("{}-{}"
+                                       .format(name, a))
+                             ['Meta']['extra-info']['vcs-revisions'][0]['date']
+                             )))
+        except Exception as e:
+            print("Exception was: {}".format(str(e)))
+            pass
+    print()
+    return results
+
+
+def print_revisions(revisions: List[Tuple[str, str]]):
+    for (name, date) in revisions:
+        print(f"{name} - {date}")
+
+
+def run():
+    charm = parse_args()
+    revisions = get_revisions(charm)
+    print_revisions(revisions)
+
+
+if __name__ == "__main__":
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ruamel.yaml < 0.15
+theblues
+libcharmstore

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,11 @@ basepython = python3
 deps = -r{toxinidir}/requirements.txt
 commands = flake8 {posargs} .
 
+[testenv:revisions]
+basepython = python3
+deps = -r{toxinidir}/requirements.txt
+commands = python3 {toxinidir}/list-revisions-in-charmstore.py {posargs}
+
 [flake8]
 ignore = E402,E226,W504
 exclude = */charmhelpers


### PR DESCRIPTION
This handy tool (tox -e revisions -- &lt;charm-name&gt;) is to enable listing
the dates of revisions of a charm in the charmstore.  e.g. it can be
used to find the first and last versions during a particular stable
series.

It's a bit buggy with some charms (wants you to login repeatedly) but that's more a function of the underlying libraries which haven't been updated in a while.  It probably needs rewriting with request and hitting the API directly, as we only want to read data, and thus shouldn't need to be authorised.