### PR TITLE
Unpin flake8 for test-requirements

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -10,7 +10,7 @@
 charm-tools>=2.4.4
 requests>=2.18.4
 mock>=1.2
-flake8>=2.2.4,<=2.4.1
+flake8>=2.2.4
 stestr>=2.2.0
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -4,7 +4,7 @@
 #     https://github.com/openstack-charmers/release-tools
 #
 # Lint and unit test requirements
-flake8>=2.2.4,<=2.4.1
+flake8>=2.2.4
 stestr>=2.2.0
 requests>=2.18.4
 charms.reactive


### PR DESCRIPTION
The current pin of flake8 makes it not check anything and return
success when executed on Python 3.8 or newer (which means Focal
and onwards, in other words the current LTS).