### PR TITLE
Add croniter dependency for rabbitmq testing

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -17,3 +17,5 @@ coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
+
+croniter            # needed for charm-rabbitmq-server unit tests


### PR DESCRIPTION
Need croniter to check test rabbitmq queue stats file. This is pulled
in from the repos on charm install, but we need to pull it in for the
unit tests here as well. Also cf. change
I60141397f39e3b1b0274230db8d984934c98a08d