### PR TITLE
Add tempest to test-requirements.txt for charm-glance

### DIFF
--- a/do-batch
+++ b/do-batch
@@ -29,7 +29,7 @@ Usage examples:
   Clone all charms, do a charm-helpers sync and a ceph sync where applicable,
   update the tox.ini files and *requirements.txt files throughout, and propose
   the change as a gerrit review.
-    ./batch-example master --sync-helpers --update-tox --update-reqs -do-clone --do-commit --do-review
+    ./batch-example master --sync-helpers --update-tox --update-reqs --do-clone --do-commit --do-review
 
   Useful for iterating over the whole set of charms as a developer:
   Note no clone, no commit, no review

--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -18,4 +18,8 @@ pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm 
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 
+# Needed for charm-glance:
+git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
+tempest;python_version<'3.6'
+
 croniter            # needed for charm-rabbitmq-server unit tests


### PR DESCRIPTION
Also fix typo

charm-glance needs tempest in its `test-requirements.txt`:
- https://opendev.org/openstack/charm-glance/src/branch/master/test-requirements.txt#L20
- https://opendev.org/openstack/charm-glance/src/branch/master/tests/tests.yaml#L46

Removing it leads to the [following error](https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_smoke/openstack/charm-glance/761556/2/20298/consoleText.test_charm_func_smoke_20053.txt):

```
Traceback (most recent call last):
  File "/tmp/tmp.al4N58v8Mn/func-smoke/bin/functest-run-suite", line 8, in <module>
    sys.exit(main())
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 278, in main
    test_directory=args.test_directory)
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 213, in func_test_runner
    force=force, test_directory=test_directory)
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/charm_lifecycle/func_test_runner.py", line 143, in run_env_deployment
    test_directory=test_directory)
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/charm_lifecycle/configure.py", line 51, in configure
    run_configure_list(functions)
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/charm_lifecycle/configure.py", line 37, in run_configure_list
    utils.get_class(func)()
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/openstack/charm_tests/tempest/setup.py", line 317, in render_tempest_config_keystone_v3
    setup_tempest('tempest_v3.j2', 'accounts.j2')
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/openstack/charm_tests/tempest/setup.py", line 291, in setup_tempest
    tempest_utils.init_workspace(workspace_path)
  File "/tmp/tmp.al4N58v8Mn/func-smoke/lib/python3.5/site-packages/zaza/openstack/charm_tests/tempest/utils.py", line 65, in init_workspace
    subprocess.check_call(['tempest', 'init', workspace_path])
  File "/usr/lib/python3.5/subprocess.py", line 576, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python3.5/subprocess.py", line 557, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.5/subprocess.py", line 947, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.5/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'tempest'
```