### PR TITLE
Support pip 20.3

### DIFF
--- a/global/classic-zaza/requirements.txt
+++ b/global/classic-zaza/requirements.txt
@@ -7,7 +7,6 @@
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
 #       all of its own requirements and if it doesn't, fix it there.
 #
-setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 pbr>=5.4.5
 simplejson>=3.17.2
 netifaces>=0.10.8

--- a/global/classic-zaza/requirements.txt
+++ b/global/classic-zaza/requirements.txt
@@ -7,16 +7,16 @@
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
 #       all of its own requirements and if it doesn't, fix it there.
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
-pbr>=1.8.0,<1.9.0
-simplejson>=2.2.0
-netifaces>=0.10.4
-netaddr>=0.7.12,!=0.7.16
-Jinja2>=2.6  # BSD License (3 clause)
-six>=1.9.0
+setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+pbr>=5.4.5
+simplejson>=3.17.2
+netifaces>=0.10.8
+netaddr>=0.8.0
+Jinja2>=2.11.2  # BSD License (3 clause)
+six>=1.14.0
 
 # dnspython 2.0.0 dropped py3.5 support
-dnspython<2.0.0; python_version < '3.6'
+dnspython>=1.15.0,<2.0.0; python_version < '3.6'
 dnspython; python_version >= '3.6'
 
-psutil>=1.1.1,<2.0.0
+psutil>=1.1.3,<2.0.0

--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -7,15 +7,15 @@
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
 #       all of its own requirements and if it doesn't, fix it there.
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
-charm-tools>=2.4.4
-requests>=2.18.4
-mock>=1.2
-flake8>=2.2.4
-stestr>=2.2.0
-coverage>=4.5.2
-pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
-git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
+setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+charm-tools>=2.7.7
+requests>=2.24.0
+mock>=3.0.4
+flake8>=3.8.3
+stestr>=2.6.0
+coverage>=5.2.1
+pyudev>=0.22.0  # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
 
 # Needed for charm-glance:

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -3,7 +3,6 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
-setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 # Build requirements
 charm-tools>=2.7.7
 # importlib-resources 1.1.0 removed Python 3.5 support

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -3,9 +3,9 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 # Build requirements
-charm-tools>=2.4.4
+charm-tools>=2.7.7
 # importlib-resources 1.1.0 removed Python 3.5 support
 importlib-resources<1.1.0
-simplejson
+simplejson>=3.17.2

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -3,22 +3,22 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+setuptools==49.6.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 # Lint and unit test requirements
-flake8>=2.2.4
-stestr>=2.2.0
-requests>=2.18.4
+flake8>=3.8.3
+stestr>=2.6.0
+requests>=2.24.0
 charms.reactive
-mock>=1.2
+mock>=3.0.4
 nose>=1.3.7
-coverage>=3.6
+coverage>=5.2.1
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
 #
 # Revisit for removal / mock improvement:
-netifaces        # vault
-psycopg2-binary  # vault
-tenacity         # vault
-pbr              # vault
-cryptography     # vault, keystone-saml-mellon
-lxml             # keystone-saml-mellon
-hvac             # vault, barbican-vault
+netifaces>=0.10.8  # vault
+psycopg2-binary    # vault
+tenacity           # vault
+pbr>=5.4.5         # vault
+cryptography       # vault, keystone-saml-mellon
+lxml               # keystone-saml-mellon
+hvac               # vault, barbican-vault


### PR DESCRIPTION
pip 20.3 just got release with a new default resolver.
We need to set higher minimum version numbers for our
dependencies because:
- the new resolver fails when parsing some old packages,
- "pip install" now may take hours if the space of
  possibilities to explore (in terms of combinations of
  possible versions) is large.

Also with the new resolvers such dependencies are considered
to be different versions and lead to a clash:
git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
git+https://github.com/openstack-charmers/zaza.git#egg=zaza

This all was leading to our unit and lint jobs failing
on pip install.