### PR TITLE
Pin pip < 20.3

### DIFF
--- a/global/classic-amulet/tox.ini
+++ b/global/classic-amulet/tox.ini
@@ -10,6 +10,11 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
+# NOTE: Avoid new dependency resolver, see
+#       https://github.com/pypa/pip/issues/9187
+#       Needs tox >= 3.2.0, see
+#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+requires = pip < 20.3
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/classic-amulet/tox.ini
+++ b/global/classic-amulet/tox.ini
@@ -15,6 +15,8 @@ skip_missing_interpreters = False
 #       Needs tox >= 3.2.0, see
 #       https://tox.readthedocs.io/en/latest/config.html#conf-requires
 requires = pip < 20.3
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/classic-zaza/requirements.txt
+++ b/global/classic-zaza/requirements.txt
@@ -7,11 +7,13 @@
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
 #       all of its own requirements and if it doesn't, fix it there.
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 pbr>=1.8.0,<1.9.0
 simplejson>=2.2.0
 netifaces>=0.10.4
-netaddr>=0.7.12,!=0.7.16
+
+# Strange import error with newer netaddr:
+netaddr>0.7.16,<0.8.0
+
 Jinja2>=2.6  # BSD License (3 clause)
 six>=1.9.0
 

--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -9,10 +9,29 @@
 #
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 charm-tools>=2.4.4
+
+# Workaround until https://github.com/juju/charm-tools/pull/589 gets
+# published
+keyring<21
+
 requests>=2.18.4
-mock>=1.2
+
+# Newer mock seems to have some syntax which is newer than python3.5 (e.g.
+# f'{something}'
+mock>=1.2,<4.0.0
+
 flake8>=2.2.4
 stestr>=2.2.0
+
+# Dependency of stestr. Workaround for
+# https://github.com/mtreinish/stestr/issues/145
+cliff<3.0.0
+
+# Dependencies of stestr. Newer versions use keywords that didn't exist in
+# python 3.5 yet (e.g. "ModuleNotFoundError")
+importlib-metadata<3.0.0
+importlib-resources<3.0.0
+
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -19,6 +19,8 @@ skip_missing_interpreters = False
 #       Needs tox >= 3.2.0, see
 #       https://tox.readthedocs.io/en/latest/config.html#conf-requires
 requires = pip < 20.3
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -14,6 +14,11 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
+# NOTE: Avoid new dependency resolver, see
+#       https://github.com/pypa/pip/issues/9187
+#       Needs tox >= 3.2.0, see
+#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+requires = pip < 20.3
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/source-amulet/src/tox.ini
+++ b/global/source-amulet/src/tox.ini
@@ -16,6 +16,8 @@ skip_missing_interpreters = False
 #       Needs tox >= 3.2.0, see
 #       https://tox.readthedocs.io/en/latest/config.html#conf-requires
 requires = pip < 20.3
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/source-amulet/src/tox.ini
+++ b/global/source-amulet/src/tox.ini
@@ -11,6 +11,11 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
+# NOTE: Avoid new dependency resolver, see
+#       https://github.com/pypa/pip/issues/9187
+#       Needs tox >= 3.2.0, see
+#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+requires = pip < 20.3
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -3,9 +3,15 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
+
 # Build requirements
 charm-tools>=2.4.4
+
+# Workaround until https://github.com/juju/charm-tools/pull/589 gets
+# published
+keyring<21
+
 # importlib-resources 1.1.0 removed Python 3.5 support
 importlib-resources<1.1.0
+
 simplejson

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -16,6 +16,8 @@ skip_missing_interpreters = False
 #       Needs tox >= 3.2.0, see
 #       https://tox.readthedocs.io/en/latest/config.html#conf-requires
 requires = pip < 20.3
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -11,6 +11,11 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
+# NOTE: Avoid new dependency resolver, see
+#       https://github.com/pypa/pip/issues/9187
+#       Needs tox >= 3.2.0, see
+#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+requires = pip < 20.3
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -6,10 +6,24 @@
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 # Lint and unit test requirements
 flake8>=2.2.4
+
 stestr>=2.2.0
+
+# Dependency of stestr. Workaround for
+# https://github.com/mtreinish/stestr/issues/145
+cliff<3.0.0
+
+# Dependencies of stestr. Newer versions use keywords that didn't exist in
+# python 3.5 yet (e.g. "ModuleNotFoundError")
+importlib-metadata<3.0.0
+
 requests>=2.18.4
 charms.reactive
-mock>=1.2
+
+# Newer mock seems to have some syntax which is newer than python3.5 (e.g.
+# f'{something}'
+mock>=1.2,<4.0.0
+
 nose>=1.3.7
 coverage>=3.6
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack


### PR DESCRIPTION
Also removing from requirements.txt what was already in
test-requirements.txt

pip 20.3 just got released with a new default resolver
which turned out to be problematic. Also pip 21 will drop
support for python 3.5 soon anyway.