### PR TITLE
Fix "ImportError: cannot import name 'resources'"

### DIFF
--- a/global/classic-amulet/tox.ini
+++ b/global/classic-amulet/tox.ini
@@ -19,7 +19,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
-           virtualenv <= 20.2.1
+           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/classic-amulet/tox.ini
+++ b/global/classic-amulet/tox.ini
@@ -10,11 +10,16 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
-# NOTE: Avoid new dependency resolver, see
-#       https://github.com/pypa/pip/issues/9187
-#       Needs tox >= 3.2.0, see
-#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
+           virtualenv <= 20.2.1
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -18,7 +18,8 @@ requests>=2.18.4
 
 # Newer mock seems to have some syntax which is newer than python3.5 (e.g.
 # f'{something}'
-mock>=1.2,<4.0.0
+mock>=1.2,<4.0.0; python_version < '3.6'
+mock>=1.2; python_version >= '3.6'
 
 flake8>=2.2.4
 stestr>=2.2.0
@@ -29,8 +30,8 @@ cliff<3.0.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
-importlib-metadata<3.0.0
-importlib-resources<3.0.0
+importlib-metadata<3.0.0; python_version < '3.6'
+importlib-resources<3.0.0; python_version < '3.6'
 
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -14,11 +14,16 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
-# NOTE: Avoid new dependency resolver, see
-#       https://github.com/pypa/pip/issues/9187
-#       Needs tox >= 3.2.0, see
-#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
+           virtualenv <= 20.2.1
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -23,7 +23,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
-           virtualenv <= 20.2.1
+           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/source-amulet/src/tox.ini
+++ b/global/source-amulet/src/tox.ini
@@ -20,7 +20,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
-           virtualenv <= 20.2.1
+           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/source-amulet/src/tox.ini
+++ b/global/source-amulet/src/tox.ini
@@ -11,11 +11,16 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
-# NOTE: Avoid new dependency resolver, see
-#       https://github.com/pypa/pip/issues/9187
-#       Needs tox >= 3.2.0, see
-#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
+           virtualenv <= 20.2.1
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -3,6 +3,10 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
+# NOTE(lourot): This might look like a duplication of test-requirements.txt but
+# some tox targets use only test-requirements.txt whereas charm-build uses only
+# requirements.txt
+setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # Build requirements
 charm-tools>=2.4.4

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -11,7 +11,4 @@ charm-tools>=2.4.4
 # published
 keyring<21
 
-# importlib-resources 1.1.0 removed Python 3.5 support
-importlib-resources<1.1.0
-
 simplejson

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -12,3 +12,11 @@ charm-tools>=2.4.4
 keyring<21
 
 simplejson
+
+# Newer versions use keywords that didn't exist in python 3.5 yet (e.g.
+# "ModuleNotFoundError")
+# NOTE(lourot): This might look like a duplication of test-requirements.txt but
+# some tox targets use only test-requirements.txt whereas charm-build uses only
+# requirements.txt
+importlib-metadata<3.0.0
+importlib-resources<3.0.0

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -22,5 +22,5 @@ simplejson
 # NOTE(lourot): This might look like a duplication of test-requirements.txt but
 # some tox targets use only test-requirements.txt whereas charm-build uses only
 # requirements.txt
-importlib-metadata<3.0.0
-importlib-resources<3.0.0
+importlib-metadata<3.0.0; python_version < '3.6'
+importlib-resources<3.0.0; python_version < '3.6'

--- a/global/source-zaza/src/test-requirements.txt
+++ b/global/source-zaza/src/test-requirements.txt
@@ -3,6 +3,13 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
+# pep8 requirements
+charm-tools>=2.4.4
+
+# Workaround until https://github.com/juju/charm-tools/pull/589 gets
+# published
+keyring<21
+
 # Functional Test Requirements (let Zaza's dependencies solve all dependencies here!)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -20,7 +20,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
-           virtualenv <= 20.2.1
+           virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -11,11 +11,16 @@ skipsdist = True
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
-# NOTE: Avoid new dependency resolver, see
-#       https://github.com/pypa/pip/issues/9187
-#       Needs tox >= 3.2.0, see
-#       https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
+           virtualenv <= 20.2.1
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -30,7 +30,6 @@ install_command =
 
 [testenv:pep8]
 basepython = python3
-deps=charm-tools
 commands = charm-proof
 
 [testenv:func-noop]

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -15,15 +15,16 @@ cliff<3.0.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
-importlib-metadata<3.0.0
-importlib-resources<3.0.0
+importlib-metadata<3.0.0; python_version < '3.6'
+importlib-resources<3.0.0; python_version < '3.6'
 
 requests>=2.18.4
 charms.reactive
 
 # Newer mock seems to have some syntax which is newer than python3.5 (e.g.
 # f'{something}'
-mock>=1.2,<4.0.0
+mock>=1.2,<4.0.0; python_version < '3.6'
+mock>=1.2; python_version >= '3.6'
 
 nose>=1.3.7
 coverage>=3.6

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -16,6 +16,7 @@ cliff<3.0.0
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
 importlib-metadata<3.0.0
+importlib-resources<3.0.0
 
 requests>=2.18.4
 charms.reactive


### PR DESCRIPTION
Similar change was done in other *requirements.txt files
in this repo but this one was missed.

Without this change we get

```
09:43:39 py35 installdeps: -r/var/lib/jenkins/checkout/6/ceph-fs/test-requirements.txt
09:44:10 py35 installed: You are using pip version 8.1.1, however version 20.3.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,certifi==2020.11.8,cffi==1.14.4,chardet==3.0.4,charmhelpers==0.20.19,charms.openstack==0.0.1.dev1,charms.reactive==1.3.2,cliff==2.18.0,cmd2==0.8.9,coverage==5.3,cryptography==3.2.1,extras==1.0.0,fixtures==3.0.0,flake8==3.8.4,future==0.18.2,hvac==0.10.5,idna==2.10,importlib-metadata==2.1.1,importlib-resources==3.3.0,Jinja2==2.11.2,linecache2==1.0.0,lxml==4.6.2,MarkupSafe==1.1.1,mccabe==0.6.1,mock==3.0.5,netaddr==0.8.0,netifaces==0.10.9,nose==1.3.7,pbr==5.5.1,pkg-resources==0.0.0,prettytable==0.7.2,psycopg2-binary==2.8.6,pyaml==20.4.0,pycodestyle==2.6.0,pycparser==2.20,pyflakes==2.2.0,pyparsing==2.4.7,pyperclip==1.8.1,python-mimeparse==1.6.0,python-subunit==1.4.0,PyYAML==5.3.1,requests==2.25.0,six==1.15.0,stestr==3.1.0,stevedore==3.3.0,Tempita==0.5.2,tenacity==6.2.0,testtools==2.4.0,traceback2==1.4.0,unittest2==1.1.0,urllib3==1.26.2,voluptuous==0.12.0,wcwidth==0.2.5,zipp==3.4.0
09:44:10 py35 run-test-pre: PYTHONHASHSEED='0'
09:44:10 py35 run-test: commands[0] | stestr run --slowest
09:44:10 
09:44:10 =========================
09:44:10 Failures during discovery
09:44:10 =========================
09:44:10 --- import errors ---
09:44:10 Failed to import test module: unit_tests.test_lib_charm_openstack_ceph_fs
09:44:10 Traceback (most recent call last):
09:44:10   File "/var/lib/jenkins/checkout/6/ceph-fs/.tox/py35/lib/python3.5/site-packages/netaddr/compat.py", line 91, in <module>
09:44:10     from importlib import resources as _importlib_resources
09:44:10 ImportError: cannot import name 'resources'
```

http://osci:8080/job/test_charm_unit/139577/console

Validating here: https://review.opendev.org/c/openstack/charm-ceph-fs/+/765506