### PR TITLE
Fix spurious Zuul failures on Python 3.5

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -33,6 +33,11 @@ cliff<3.0.0
 importlib-metadata<3.0.0; python_version < '3.6'
 importlib-resources<3.0.0; python_version < '3.6'
 
+# Some Zuul nodes sometimes pull newer versions of these dependencies which
+# dropped support for python 3.5:
+osprofiler<2.7.0;python_version<'3.6'
+stevedore<1.31.0;python_version<'3.6'
+
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'
@@ -40,6 +45,6 @@ git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.open
 
 # Needed for charm-glance:
 git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
-tempest;python_version<'3.6'
+tempest<24.0.0;python_version<'3.6'
 
 croniter            # needed for charm-rabbitmq-server unit tests

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -18,6 +18,11 @@ cliff<3.0.0
 importlib-metadata<3.0.0; python_version < '3.6'
 importlib-resources<3.0.0; python_version < '3.6'
 
+# Some Zuul nodes sometimes pull newer versions of these dependencies which
+# dropped support for python 3.5:
+osprofiler<2.7.0;python_version<'3.6'
+stevedore<1.31.0;python_version<'3.6'
+
 requests>=2.18.4
 charms.reactive
 


### PR DESCRIPTION
Examples of such spurious failures:

- `stevedore`
  - https://review.opendev.org/c/openstack/charm-neutron-gateway/+/766595
  - https://zuul.opendev.org/t/openstack/build/bae9626ee0794c789f714bce6fedc8a9
- `osprofiler`
  - https://review.opendev.org/c/openstack/charm-nova-compute/+/766599
  - https://zuul.opendev.org/t/openstack/build/a7cff4a71bb147a8b41a50186c446cf2
- `tempest`
  - https://review.opendev.org/c/openstack/charm-ceilometer/+/766555
  - https://zuul.opendev.org/t/openstack/build/dd4365dea0da4c91a8fef607cf9df059
