### PR TITLE
Fix spurious Zuul failures on Python 3.5

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -37,6 +37,8 @@ importlib-resources<3.0.0; python_version < '3.6'
 # dropped support for python 3.5:
 osprofiler<2.7.0;python_version<'3.6'
 stevedore<1.31.0;python_version<'3.6'
+debtcollector<1.22.0;python_version<'3.6'
+oslo.utils<=3.41.0;python_version<'3.6'
 
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -22,6 +22,8 @@ importlib-resources<3.0.0; python_version < '3.6'
 # dropped support for python 3.5:
 osprofiler<2.7.0;python_version<'3.6'
 stevedore<1.31.0;python_version<'3.6'
+debtcollector<1.22.0;python_version<'3.6'
+oslo.utils<=3.41.0;python_version<'3.6'
 
 requests>=2.18.4
 charms.reactive


### PR DESCRIPTION
Examples of such spurious failures:

- `debtcollector`
  - https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/766562
  - https://zuul.opendev.org/t/openstack/build/a7525f4a626f4939b48c2b33690ce7f1
- `oslo.utils`
  - https://review.opendev.org/c/openstack/charm-nova-compute/+/766599
  - https://zuul.opendev.org/t/openstack/build/7abf8f264fe24e94aba48c48f9cc8330
