### PR TITLE
Pin charm-tools (for build) to 2.8.3 for 21.04 cycle

### DIFF
--- a/build-charm
+++ b/build-charm
@@ -97,12 +97,12 @@ function validate_build_charm_r () {
   local charm_name="${2}"
   local required_files="${3}"
 
-  # NOTE(lourot): starting with charm-tools>=2.8 the behaviour will be different
-  # and the EXPECTED_BUILD_DIR won't depend on having `series` in metadata.yaml
-  # anymore but will simply always be:
-  # EXPECTED_BUILD_DIR="$charm_dir/build/$charm_name"
-  # Note that the `builds/` subfolder has vanished.
-  # This works only up to charm-tools 2.7:
+  # NOTE(ajkavanagh): starting with charm-tools>=2.8 the default behaviour of
+  # the charm build '-d' option has changed, in that in no longer appends
+  # 'builds' to the directory.  However, as we need to support both stable
+  # (charm-tools < 2.8) and master (charm-tools >=2.8), the tox for master now
+  # forces the build into the same ./build/builds/ directory.
+  # This note can be reviewed in the post 21.04 cycle.
   if grep '^\"\?series\"\?:$' $charm_dir/src/metadata.yaml &> /dev/null; then
     echo " . $charm_dir is a multi-series charm based on its metadata.yaml"
     EXPECTED_BUILD_DIR="$charm_dir/build/builds/$charm_name"

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -9,7 +9,7 @@
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # Build requirements
-charm-tools>=2.4.4
+charm-tools==2.8.3
 
 # Workaround until https://github.com/juju/charm-tools/pull/589 gets
 # published

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -28,7 +28,7 @@ deps =
 [testenv:build]
 basepython = python3
 commands =
-    charm-build --log-level DEBUG -o {toxinidir}/build src {posargs}
+    charm-build --log-level DEBUG -o {toxinidir}/build/builds src {posargs}
 
 [testenv:py3]
 basepython = python3


### PR DESCRIPTION
This PR pins charm-tools to 2.8.3 for the reactive builds for the 21.04
development cycle.  The tox.ini is modified to keep the builds in the
build/builds/<charm>  directory as this has been 'fixed' in 2.8.2+ to
build/<charm>.  In order to keep the release tooling consistent between
the stable and master branches the build/builds/<charm> option is used.