### PR TITLE
Updates to support reproducible charms

### DIFF
--- a/_do-actual-builds
+++ b/_do-actual-builds
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+#  Build only reactive charms; requires the charms to have been synced using
+# ./get-charms
+
+charms="$(cat charms.txt)"
+
+for charm in $charms; do
+    if [ ! -d "charms/$charm" ]; then
+        echo "Use ./get-charms master to clone the charm dirs first ($charm not found)"
+        exit 1
+    fi
+done
+
+for charm in $charms; do
+    charm_type="$(./what-is charms/$charm)"
+    echo "===== $charm ($charm_type) ====="
+    (
+        # Do a charm-helpers sync where possible
+        cd "charms/$charm"
+        case $charm_type in
+            source-zaza | source-amulet)
+                # Build the charm.
+                tox -e build
+                ;;
+            classic-zaza | classic-amulet)
+                echo "NOOP on $charm as it is a classic charm."
+                ;;
+            *)
+                echo "UNKNOWN TYPE" && exit 1
+                ;;
+        esac
+
+    )
+done
+

--- a/_do-batch-add-build-lock-file
+++ b/_do-batch-add-build-lock-file
@@ -1,8 +1,9 @@
 #!/bin/bash -e
-#  Build only reactive charms; requires the charms to have been synced using
+#  Build only reactive charms with build.lock files; requires the charms to have been synced using
 # ./get-charms
 
 charms="$(cat charms.txt)"
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 for charm in $charms; do
     if [ ! -d "charms/$charm" ]; then
@@ -15,12 +16,11 @@ for charm in $charms; do
     charm_type="$(./what-is charms/$charm)"
     echo "===== $charm ($charm_type) ====="
     (
-        # Do a charm-helpers sync where possible
         cd "charms/$charm"
         case $charm_type in
             source-zaza | source-amulet)
-                # Build the charm.
-                tox -e build
+                # Build the charm with a lock file and clean-up afterwards
+                ${_dir}/add-build-lock-file
                 ;;
             classic-zaza | classic-amulet)
                 echo "NOOP on $charm as it is a classic charm."

--- a/_do-batch-flip-master-libs-to-stable
+++ b/_do-batch-flip-master-libs-to-stable
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+#  For all the charms, flip the master libs to stable ON THE MASTER branch
+# This is for the freeze period and ensures that during freeze the charms only
+# take updates from the stable libraries.
+# ./get-charms
+
+release="$1"
+
+if [ -z "$release" ]; then
+    echo "Please provide release as only parameter"
+    exit 1
+fi
+
+charms="$(cat charms.txt)"
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+for charm in $charms; do
+    if [ ! -d "charms/$charm" ]; then
+        echo "Use ./get-charms master to clone the charm dirs first ($charm not found)"
+        exit 1
+    fi
+done
+
+for charm in $charms; do
+    charm_type="$(./what-is charms/$charm)"
+    echo "===== $charm ($charm_type) ====="
+    (
+        cd "charms/$charm"
+        ${_dir}/flip-master-libs-to-stable $release
+    )
+done
+

--- a/_do-clean-reactive
+++ b/_do-clean-reactive
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+#  Clean-up the build and .tox directories after a build for reactive charms.
+#  This is used after a build step when making reproducible reactive charms.
+
+charms="$(cat charms.txt)"
+
+for charm in $charms; do
+    if [ ! -d "charms/$charm" ]; then
+        echo "Use ./get-charms master to clone the charm dirs first ($charm not found)"
+        exit 1
+    fi
+done
+
+for charm in $charms; do
+    charm_type="$(./what-is charms/$charm)"
+    echo "===== $charm ($charm_type) ====="
+    (
+        cd "charms/$charm"
+        case $charm_type in
+            source-zaza | source-amulet)
+                rm -rf build
+                rm -rf .tox
+                ;;
+            classic-zaza | classic-amulet)
+                echo "NOOP on $charm as it is a classic charm."
+                ;;
+            *)
+                echo "UNKNOWN TYPE" && exit 1
+                ;;
+        esac
+
+    )
+done
+

--- a/_update-metadata.py
+++ b/_update-metadata.py
@@ -53,8 +53,9 @@ def run_command(cmd, yml):
         add_series(cmd, yml)
     elif cmd.cmd == "remove":
         remove_series(cmd, yml)
-    elif cmd.cmd == "ensure":
-        ensure_series_is(cmd, yml)
+    # NOTE(ajkavanagh) - this hasn't actually been written yet.
+    # elif cmd.cmd == "ensure":
+    #     ensure_series_is(cmd, yml)
     else:
         print("Command?? {}".format(cmd))
         sys.exit(1)
@@ -96,6 +97,17 @@ def add_series(cmd, yml):
     yml['series'].append(series)
     print("Adding series '{}' to metadata".format(series))
     write_yaml(cmd, yml)
+
+
+def remove_series(cmd, yml):
+    series = cmd.params[0].lower()
+    if series not in yml['series']:
+        print("Series '{}' not present; ignoring remove".format(series))
+        return
+    yml['series'].remove(series)
+    print("Removed series '{}' from metadata".format(series))
+    write_yaml(cmd, yml)
+
 
 def run():
     cmd = parse_args()

--- a/add-build-lock-file
+++ b/add-build-lock-file
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+# Add a lock file to the charm (assume it is a reactive charm).
+# Run in the charm's root directory.
+# Uses the 'add-build-lock-file' tox target.
+# then cleans up afterwards.
+# Run AFTER switching the charm to stable libraries (flip-master-libs-to-stable)
+
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+charm_type="$(${_dir}/what-is .)"
+
+case $charm_type in
+    source-zaza | source-amulet)
+        # Build the charm.
+        if [ ! -f src/build.lock ]; then
+            tox -e add-build-lock-file
+            rm -rf .tox
+            rm -rf build
+            # temporarily workaround the stable branch detection - charm-tools Bug: #606
+            sed -i "s#refs/heads/master\\\\nrefs/heads/stable/#refs/heads/stable/#g" src/build.lock
+        fi
+        ;;
+    *)
+        ;;
+esac
+

--- a/do-batch
+++ b/do-batch
@@ -146,12 +146,10 @@ for charm in $charms; do
       git checkout -b $gerrit_topic
       git add .
       git commit -F $commit_msg_file
-      git_review
     elif [[ "$all_params" == *--amend* ]] && [[ "$all_params" == *--do-commit* ]] && [[ -n "$git_status" ]]; then
       git checkout $gerrit_topic || git checkout -b $gerrit_topic
       git add .
       git commit --amend -F $commit_msg_file
-      git_review
     elif [[ "$all_params" == *--do-review* ]]; then
       git_review || true
     else

--- a/flip-master-libs-to-stable
+++ b/flip-master-libs-to-stable
@@ -23,11 +23,9 @@ fi
 for ch in charm-helpers-hooks.yaml charm-helpers-tests.yaml; do
     if [ -f $ch ]; then
         sed -i "s/https\:\/\/github.com\/juju\/charm-helpers$/https\:\/\/github.com\/juju\/charm-helpers\@stable\/${release}/g" $ch
-        #git add $ch
     fi
     if [ -f src/$ch ]; then
         sed -i "s/https\:\/\/github.com\/juju\/charm-helpers$/https\:\/\/github.com\/juju\/charm-helpers\@stable\/${release}/g" src/$ch
-        #git add src/$ch
     fi
 done
 

--- a/flip-master-libs-to-stable
+++ b/flip-master-libs-to-stable
@@ -1,0 +1,62 @@
+#!/bin/bash -e
+#
+# Freeze tasks for 21.04+ (flipping branches to stable)
+# - charm-helpers
+# - charms.openstack
+# - charms.ceph
+# - zaza
+# - zaza-openstack-tests
+#
+# DOES NOT flip the .gitreview nor update the tests bundles
+#
+# the release (21.xx) is in the 1st param.
+# Run in the directory of the charm that is to be flipped.
+# Does NOT stage commits.
+
+release="$1"
+
+if [ -z "$release" ]; then
+    echo "Please provide release as only parameter"
+    exit 1
+fi
+
+for ch in charm-helpers-hooks.yaml charm-helpers-tests.yaml; do
+    if [ -f $ch ]; then
+        sed -i "s/https\:\/\/github.com\/juju\/charm-helpers$/https\:\/\/github.com\/juju\/charm-helpers\@stable\/${release}/g" $ch
+        #git add $ch
+    fi
+    if [ -f src/$ch ]; then
+        sed -i "s/https\:\/\/github.com\/juju\/charm-helpers$/https\:\/\/github.com\/juju\/charm-helpers\@stable\/${release}/g" src/$ch
+        #git add src/$ch
+    fi
+done
+
+if [ -f src/layer.yaml ]; then
+    set +e
+        grep -q charms.openstack.git@stable src/wheelhouse.txt 2>/dev/null || {
+            echo "Updating charm wheelhouse, with stable 'charms.openstack'"
+            sed -i "s#openstack/charms.openstack.git#openstack/charms.openstack.git@stable/$release#g" src/wheelhouse.txt
+        }
+        grep -q charm-helpers.git@stable src/wheelhouse.txt 2>/dev/null || {
+            echo "Updating charm wheelhouse, with stable 'charmhelpers'"
+            sed -i "s#juju/charm-helpers.git#juju/charm-helpers.git@stable/${release}#g" src/wheelhouse.txt
+        }
+        grep -q charms.openstack.git@stable tests-requirements.txt 2>/dev/null || {
+            echo "Updating test-requirements.txt in repository with stable charms.openstack"
+            sed -i "s#openstack/charms.openstack.git#openstack/charms.openstack.git@stable/$release#g" test-requirements.txt
+        }
+        grep -q zaza-openstack-tests.git@stable src/tests-requirements.txt 2>/dev/null || {
+            echo "Updating src/test-requirements.txt in repository with stable Zaza"
+            sed -i "s#openstack-charmers/zaza.git#openstack-charmers/zaza.git@stable/$release#g" src/test-requirements.txt
+            sed -i "s#openstack-charmers/zaza-openstack-tests.git#openstack-charmers/zaza-openstack-tests.git@stable/$release#g" src/test-requirements.txt
+        }
+    set -e
+else
+    set +e
+        grep -q zaza-openstack-tests.git@stable tests-requirements.txt 2>/dev/null || {
+            echo "Updating test-requirements.txt in repository with stable Zaza"
+            sed -i "s#openstack-charmers/zaza.git#openstack-charmers/zaza.git@stable/$release#g" test-requirements.txt
+            sed -i "s#openstack-charmers/zaza-openstack-tests.git#openstack-charmers/zaza-openstack-tests.git@stable/$release#g" test-requirements.txt
+        }
+    set -e
+fi

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -28,7 +28,12 @@ deps =
 [testenv:build]
 basepython = python3
 commands =
-    charm-build --log-level DEBUG -o {toxinidir}/build/builds src {posargs}
+    charm-build --log-level DEBUG --use-lock-file-branches -o {toxinidir}/build/builds src {posargs}
+
+[testenv:add-build-lock-file]
+basepython = python3
+commands =
+    charm-build --log-level DEBUG --write-lock-file -o {toxinidir}/build/builds src {posargs}
 
 [testenv:py3]
 basepython = python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-#ruamel.yaml < 0.15
 ruamel.yaml
 theblues
 libcharmstore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-ruamel.yaml < 0.15
+#ruamel.yaml < 0.15
+ruamel.yaml
 theblues
 libcharmstore


### PR DESCRIPTION
The reproducible charms feature requires building the charms with an
additional option.  This then introduces a build.lock file which is then
used to produce reproducible charms.

This set of commits is to provide the tooling in release tools to update master branch charms (which do not use reproducible builds) into a stable set that does use reproducible builds.