### PR TITLE
Add helper to flip all charms back to master on master branch

### DIFF
--- a/_ensure_master_libraries_all_charms
+++ b/_ensure_master_libraries_all_charms
@@ -1,0 +1,89 @@
+#!/bin/bash -e
+#
+# Ensure that charm-helpers, charms.openstack, charms.ceph, zaza and
+# zaza-openstack-tests are from the master branch.
+
+charms="$(cat charms.txt)"
+basedir="$(pwd)"
+
+
+function ensure_line {
+    search="$1"
+    add_line="$2"
+    file="$3"
+    if grep "$search" "$file" >/dev/null; then
+        # line exists so replace it.
+        cmd="/$search/c\\$add_line"
+        #$(sed -i $cmd src/wheelhouse.txt)
+        $(sed -i $cmd $file)
+    else
+        # line doesn't exist so add it
+        echo -e "\n$add_line" >> $file
+    fi
+}
+
+
+function ensure_line_if_exists {
+    search="$1"
+    add_line="$2"
+    file="$3"
+    if grep "$search" "$file" >/dev/null; then
+        # line exists so replace it.
+        cmd="/$search/c\\$add_line"
+        #$(sed -i $cmd src/wheelhouse.txt)
+        $(sed -i $cmd $file)
+    fi
+}
+
+
+# the directory needs to be in the root for the charm repo for this function
+function ensure_lines {
+    charm_type="$($basedir/what-is .)"
+    case $charm_type in
+        classic-zaza | classic-amulet)
+            echo "$charm is a classic charm - possibly making changes."
+
+            # charm-helpers-hooks.yaml
+            ensure_line "charm-helpers" "https://github.com/juju/charm-helpers" "charm-helpers-hooks.yaml"
+
+            # test-requirements.txt
+            ensure_line "zaza.git" "git+https://github.org/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'" "test-requirements.txt"
+            ensure_line "zaza-openstack-tests" "git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack" "test-requirements.txt"
+            ;;
+
+        source-zaza | source-amulet)
+            echo "$charm is a source charm (reactive) - possibly making changes"
+
+            # src/wheelhouse.txt
+            ensure_line "charms.openstack" "git+https://opendev.org/openstack/charms.openstack.git#egg=charms.openstack" "src/wheelhouse.txt"
+            ensure_line "charm-helpers" "git+https://github.com/juju/charm-helpers.git#egg=charmhelpers" "src/wheelhouse.txt"
+            ensure_line_if_exists "charms.ceph" "git+https://github.com/openstack/charms.ceph.git#egg=charms.ceph" "src/wheelhouse.txt"
+
+            # test-requirements.txt
+            ensure_line "charms.openstack" "git+https://opendev.org/openstack/charms.openstack.git#egg=charms.openstack" "test-requirements.txt"
+
+            # src/test-requirements.txt
+            ensure_line "zaza.git" "git+https://github.org/openstack-charmers/zaza.git#egg=zaza;python_version>='3.0'" "src/test-requirements.txt"
+            ensure_line "zaza-openstack-tests" "git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack" "src/test-requirements.txt"
+
+            # remote the build lock if present
+            remove_build_lock_if_present
+            ;;
+    esac
+}
+
+
+function remove_build_lock_if_present {
+    test -e src/build.lock && rm src/build.lock
+}
+
+for charm in $charms; do
+    if [ ! -d "charms/$charm" ]; then
+        echo "charm dir $charm is missing. exiting"
+        exit 1
+    fi
+    (
+        cd charms/$charm
+        ensure_lines
+    )
+done


### PR DESCRIPTION
The "interim" release policy had stable/yy.mm branches for
charm-helpers, charms.openstack, charms.ceph, zaza and
zaza-openstack-tests referenced in various requirements files on the
master branch.  These need to be flipped back to master once release is
done.