### PR TITLE
Fix update-charms-metadata arg parsing

### DIFF
--- a/update-charms-metadata
+++ b/update-charms-metadata
@@ -4,7 +4,6 @@
 charms="$(cat charms.txt)"
 cmd=$1
 shift
-shift
 params=$@
 
 if [ ! -d ".tox/py3" ]; then


### PR DESCRIPTION
Without this fix:

```
$ ./update-charms-metadata add groovy
...
Command 'add' requires at least 1 argument
usage: _update-metadata.py [list | add | remove | ensure] [<series, ...]
```