### PR TITLE
Change minversion in tox to 3.18.0

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -25,7 +25,7 @@ skip_missing_interpreters = False
 requires = pip < 20.3
            virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
-minversion = 3.2.0
+minversion = 3.18.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -34,7 +34,7 @@ setenv = VIRTUAL_ENV={envdir}
 install_command =
   pip install {opts} {packages}
 commands = stestr run --slowest {posargs}
-whitelist_externals = juju
+allowlist_externals = juju
 passenv = HOME TERM CS_* OS_* TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -22,12 +22,12 @@ skip_missing_interpreters = False
 requires = pip < 20.3
            virtualenv < 20.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
-minversion = 3.2.0
+minversion = 3.18.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
-whitelist_externals = juju
+allowlist_externals = juju
 passenv = HOME TERM CS_* OS_* TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 install_command =


### PR DESCRIPTION
The patch bumps min version of tox to 3.18.0 in order to
replace tox's whitelist_externals by allowlist_externals option:
https://github.com/tox-dev/tox/blob/master/docs/changelog.rst#v3180-2020-07-23

Co-Authored-By: likui <likui@yovole.com>

Copied from and validated in https://review.opendev.org/c/openstack/charm-ceph-mon/+/803910