### PR TITLE
Wrap pip to force pip<20.3 and setuptools<50.0.0

### DIFF
--- a/global/classic-zaza/pip.sh
+++ b/global/classic-zaza/pip.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# setuptools 58.0 dropped the support for use_2to3=true which is needed to
+# install blessings (an indirect dependency of charm-tools).
+#
+# More details on the beahvior of tox and virtualenv creation can be found at
+# https://github.com/tox-dev/tox/issues/448
+#
+# This script is wrapper to force the use of the pinned versions early in the
+# process when the virtualenv was created and upgraded before installing the
+# depedencies declared in the target.
+pip install 'pip<20.3' 'setuptools<50.0.0'
+pip "$@"

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -22,8 +22,11 @@ skip_missing_interpreters = False
 # * It is also necessary to pin virtualenv as a newer virtualenv would still
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
-requires = pip < 20.3
-           virtualenv < 20.0
+requires =
+  pip < 20.3
+  virtualenv < 20.0
+  setuptools < 50.0.0
+
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.18.0
 
@@ -32,7 +35,7 @@ setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
          CHARM_DIR={envdir}
 install_command =
-  pip install {opts} {packages}
+  {toxinidir}/pip.sh install {opts} {packages}
 commands = stestr run --slowest {posargs}
 allowlist_externals = juju
 passenv = HOME TERM CS_* OS_* TEST_*

--- a/global/source-zaza/pip.sh
+++ b/global/source-zaza/pip.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# setuptools 58.0 dropped the support for use_2to3=true which is needed to
+# install blessings (an indirect dependency of charm-tools).
+#
+# More details on the beahvior of tox and virtualenv creation can be found at
+# https://github.com/tox-dev/tox/issues/448
+#
+# This script is wrapper to force the use of the pinned versions early in the
+# process when the virtualenv was created and upgraded before installing the
+# depedencies declared in the target.
+pip install 'pip<20.3' 'setuptools<50.0.0'
+pip "$@"

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -11,6 +11,21 @@ envlist = pep8,py3
 sitepackages = False
 # NOTE: Avoid false positives by not skipping missing interpreters.
 skip_missing_interpreters = False
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires =
+  pip < 20.3
+  virtualenv < 20.0
+  setuptools<50.0.0
+
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.18.0
 
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
@@ -21,7 +36,7 @@ setenv = VIRTUAL_ENV={envdir}
          JUJU_REPOSITORY={toxinidir}/build
 passenv = http_proxy https_proxy INTERFACE_PATH LAYER_PATH JUJU_REPOSITORY
 install_command =
-  pip install {opts} {packages}
+  {toxinidir}/pip.sh install {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt
 


### PR DESCRIPTION
Osci runs the CI jobs on Bionic, this version of tox (2.5) will
automatically upgrade the packages at virtualenv creation and any
pinning won't have effect since the virtualenv created is upgraded to
the latest versions of pip and setuptools. This behavior was changed in
tox 3.10 with the addition of the 'download' directive[0]

Setuptools 58.0 dropped the support for use_2to3=true which is needed to
install blessings (an indirect dependency of charm-tools) since then
the gate got broken.

Closes #155

[0] https://github.com/tox-dev/tox/commit/18147f4c5af75caf40c3c2f95a0907da2db83deb