### PR TITLE
Fix copy of pip.sh

### DIFF
--- a/_update-tox-files
+++ b/_update-tox-files
@@ -20,11 +20,11 @@ for charm in $charms; do
         case $charm_type in
             classic-zaza)
                 cp -fvp global/$charm_type/tox.ini charms/$charm/tox.ini
-                cp -fvp global/$charm_type/tox.ini charms/$charm/pip.sh
+                cp -fvp global/$charm_type/pip.sh charms/$charm/pip.sh
                 ;;
             source-zaza)
                 cp -fvp global/$charm_type/tox.ini charms/$charm/tox.ini
-                cp -fvp global/$charm_type/tox.ini charms/$charm/pip.sh
+                cp -fvp global/$charm_type/pip.sh charms/$charm/pip.sh
                 cp -fvp global/$charm_type/src/tox.ini charms/$charm/src/tox.ini
                 ;;
             *)


### PR DESCRIPTION
This change fixes the copy of pip.sh which was using tox.ini as the
source file instead of pip.sh.