### PR TITLE
Fix push-and-release and add stable -> candidate copier

### DIFF
--- a/_do-batch-cp-stable-candidate
+++ b/_do-batch-cp-stable-candidate
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+#  Build only reactive charms with build.lock files; requires the charms to have been synced using
+# ./get-charms
+
+charms="$(cat charms.txt)"
+_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+
+for charm in $charms; do
+    echo "===== $charm ====="
+    full_charm="cs:~openstack-charmers/$charm"
+    id_revision=$(charm show "$full_charm" --channel stable id | grep -e "Id: $full_charm" | xargs | cut -d " " -f 2)
+    if [ -z "$id_revision" ]; then
+        echo "Nothing to do."
+    else
+        echo "Charm revision is $id_revision"
+
+        # now get the resources:
+        resources_line=$(charm show "$full_charm" resources | yq eval '.resources[] | "--resource " + .Name + "-" + .Revision' - | tr '\n' ' ')
+        echo "resource line is: $resources_line"
+
+        # now try to release it.
+        echo "Running >> charm release $id_revision $resources_line --channel=candidate"
+        charm release $id_revision $resources_line --channel=candidate
+        echo "Running >> charm grant $full_charm --channel candidate --acl read everyone"
+        charm grant $full_charm --channel candidate --acl read everyone
+    fi
+done
+

--- a/push-and-release
+++ b/push-and-release
@@ -128,7 +128,7 @@ case "$channel_lc" in
         channel_lc="stable"
     ;;
     candidate|beta|edge)
-        channel_spec="--channel=$charm_lc"
+        channel_spec="--channel=$channel_lc"
     ;;
     *)
         echo " ! channel "$channel" is not one of stable, candidate, beta, edge."
@@ -199,7 +199,7 @@ echo " . Releasing charm $charm_ref to channel $channel_lc"
 retry_command charm release $charm_ref $resource_string $channel_spec
 
 echo " . Granting global read acl"
-retry_command charm grant $charm_store_url --acl read everyone
+retry_command charm grant $charm_store_url $channel_spec --acl read everyone
 
 echo " . Setting charm homepage and bugs-url options"
 


### PR DESCRIPTION
This fixes push-and-release so that it does a charm grant for the
channel, as apparently the charmstore has to have the channel version
granted.

The 2nd part is a helper script to copy the current stable channel charm
to the candidate release channel (and grant it).  This is to provide a
'starting' point so that charm pull <charm> --channel=candidate has
something to work with.  It would appear that the charmstore randomly
will not provide a charm if a channel is provided that hasn't been
pushed to (which kind of means 'auto-promotion' to a more stable version
doesn't work.)