### PR TITLE
Add glance-ss snap resource for master pusher.

### DIFF
--- a/resources.txt
+++ b/resources.txt
@@ -17,6 +17,7 @@ designate:stable/21.10:policyd-override:policyd-override-0:zip
 glance:master:policyd-override:policyd-override-0:zip
 glance:stable/21.04:policyd-override:policyd-override-0:zip
 glance:stable/21.10:policyd-override:policyd-override-0:zip
+glance-simplestreams-sync:master:simplestreams:simplestreams-0:snap
 gnocchi:master:policyd-override:policyd-override-0:zip
 gnocchi:stable/21.04:policyd-override:policyd-override-0:zip
 gnocchi:stable/21.10:policyd-override:policyd-override-0:zip


### PR DESCRIPTION
At change I5f21ca9faff35427281076e142942c3458e71091 the gss charm gained
a resource; thus it needs to be given one when the charm is pushed.