### PR TITLE
Pin CFFI for charm build

### DIFF
--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -9,6 +9,7 @@
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # Build requirements
+cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
 charm-tools==2.8.3
 
 simplejson


### PR DESCRIPTION
Charms are currently built on xenial and so cffi needs to be pinned for
the build phase.  This needs to be copied to each reactive charm.