### PR TITLE
Pin pyparsing < 3.0.0 for aodhclient < 1.4.0

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -7,6 +7,7 @@
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
 #       all of its own requirements and if it doesn't, fix it there.
 #
+pyparsing<3.0.0  # aodhclient is pinned in zaza and needs pyparsing < 3.0.0, but cffi also needs it, so pin here.
 cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -3,6 +3,7 @@
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
 #
+pyparsing<3.0.0  # aodhclient is pinned in zaza and needs pyparsing < 3.0.0, but cffi also needs it, so pin here.
 cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
 setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 


### PR DESCRIPTION
zaza-openstack-tests pins aodhclient < 1.4.0 and this requires pyparsing
to be pinned to < 3.0.0.