### PR TITLE
Add py39 tox.ini targets

### DIFF
--- a/global/classic-zaza/test-requirements.txt
+++ b/global/classic-zaza/test-requirements.txt
@@ -46,4 +46,3 @@ git+https://opendev.org/openstack/tempest.git#egg=tempest;python_version>='3.6'
 tempest<24.0.0;python_version<'3.6'
 
 croniter            # needed for charm-rabbitmq-server unit tests
-psutil              # ceilometer

--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -61,6 +61,11 @@ basepython = python3.8
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 
+[testenv:py39]
+basepython = python3.9
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+
 [testenv:py3]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -75,6 +75,11 @@ basepython = python3.8
 deps = -r{toxinidir}/test-requirements.txt
 commands = stestr run --slowest {posargs}
 
+[testenv:py39]
+basepython = python3.9
+deps = -r{toxinidir}/test-requirements.txt
+commands = stestr run --slowest {posargs}
+
 [testenv:pep8]
 basepython = python3
 deps = flake8==3.9.2


### PR DESCRIPTION
This patch reverts "Add psutil to test-requirements for ceilometer" and
adds py39 tox targets.

The test-requirements.txt change is not needed since requirements.txt
already specifies psutil. Instead, py39 tox targets are needed that depend
on the correct requirements file(s).

This reverts commit f6c264ad3cc779e4abf84e1f5a423e73df2320ac.