### PR TITLE
Add charmcraft yaml templates for reactive/classic charms

### DIFF
--- a/global/classic-zaza/charmcraft.yaml
+++ b/global/classic-zaza/charmcraft.yaml
@@ -1,0 +1,27 @@
+type: charm
+
+parts:
+  charm:
+    plugin: dump
+    source: .
+    prime:
+      - actions/*
+      - files/*
+      - hooks/*
+      - lib/*
+      - templates/*
+      - actions.yaml
+      - config.yaml
+      - copyright
+      - hardening.yaml
+      - icon.svg
+      - LICENSE
+      - Makefile
+      - metadata.yaml
+      - README.md
+
+bases:
+  - name: ubuntu
+    channel: "20.04"
+    architectures:
+      - amd64

--- a/global/source-zaza/charmcraft.yaml
+++ b/global/source-zaza/charmcraft.yaml
@@ -1,0 +1,13 @@
+type: charm
+
+parts:
+  charm:
+    source: src/
+    plugin: reactive
+    build-snaps: [charm]
+
+bases:
+  - name: ubuntu
+    channel: "20.04"
+    architectures:
+      - amd64


### PR DESCRIPTION
These are the default charmcraft.yaml files for charmcraft to build
classic and reactive charms using the appropriate plugins.