### PR TITLE
Update the _do-amend-review to not change the topic

### DIFF
--- a/_do-amend-review
+++ b/_do-amend-review
@@ -3,7 +3,6 @@
 #  This is used after a build step when making reproducible reactive charms.
 
 charms="$(cat charms.txt)"
-topic=$1
 
 for charm in $charms; do
     if [ ! -d "charms/$charm" ]; then
@@ -17,9 +16,12 @@ for charm in $charms; do
     echo "===== $charm ($charm_type) ====="
     (
         cd "charms/$charm"
-        git add .
-        git commit --amend --no-edit
-        git review -t $topic
+        git_status="$(git status -s)"
+        if [ -n "$git_status" ]; then
+            git add .
+            git commit --amend --no-edit
+            git review -T
+        fi
     )
 done
 


### PR DESCRIPTION
It turns out the script is more useful if it just stages all the files
in the charm repo, updates the commit without needing an edit and then
does the git review without changing the topic.