### PR TITLE
Updates to global files for reactive charms, charmcraft and charmhub

### DIFF
--- a/global/source-zaza/build-requirements.txt
+++ b/global/source-zaza/build-requirements.txt
@@ -1,0 +1,7 @@
+# NOTES(lourot):
+# * We don't install charmcraft via pip anymore because it anyway spins up a
+#   container and scp the system's charmcraft snap inside it. So the charmcraft
+#   snap is necessary on the system anyway.
+# * `tox -e build` successfully validated with charmcraft 1.2.1
+
+cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.

--- a/global/source-zaza/charmcraft.yaml
+++ b/global/source-zaza/charmcraft.yaml
@@ -2,9 +2,21 @@ type: charm
 
 parts:
   charm:
-    source: src/
-    plugin: reactive
-    build-snaps: [charm]
+    build-packages:
+      - tox
+      - git
+      - python3-dev
+    override-build: |
+      apt-get install ca-certificates -y
+      tox -e build-reactive
+    override-stage: |
+      echo "Copying charm to staging area: $CHARMCRAFT_STAGE"
+      NAME=$(ls $CHARMCRAFT_PART_BUILD/build/builds)
+      cp -r $CHARMCRAFT_PART_BUILD/build/builds/$NAME/* $CHARMCRAFT_STAGE/
+    override-prime: |
+      # For some reason, the normal priming chokes on the fact that there's a
+      # hooks directory.
+      cp -r $CHARMCRAFT_STAGE/* .
 
 bases:
   - name: ubuntu

--- a/global/source-zaza/rename.sh
+++ b/global/source-zaza/rename.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+charm=$(grep "charm_build_name" osci.yaml | awk '{print $2}')
+echo "renaming ${charm}_*.charm to ${charm}.charm"
+echo -n "pwd: "
+pwd
+ls -al
+echo "Removing bad downloaded charm maybe?"
+if [[ -e "${charm}.charm" ]];
+then
+    rm "${charm}.charm"
+fi
+echo "Renaming charm here."
+mv ${charm}_*.charm ${charm}.charm

--- a/global/source-zaza/test-requirements.txt
+++ b/global/source-zaza/test-requirements.txt
@@ -28,6 +28,11 @@ oslo.utils<=3.41.0;python_version<'3.6'
 requests>=2.18.4
 charms.reactive
 
+# Newer mock seems to have some syntax which is newer than python3.5 (e.g.
+# f'{something}'
+mock>=1.2,<4.0.0; python_version < '3.6'
+mock>=1.2; python_version >= '3.6'
+
 nose>=1.3.7
 coverage>=3.6
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -37,10 +37,23 @@ setenv = VIRTUAL_ENV={envdir}
 passenv = http_proxy https_proxy INTERFACE_PATH LAYER_PATH JUJU_REPOSITORY
 install_command =
   {toxinidir}/pip.sh install {opts} {packages}
+allowlist_externals =
+    charmcraft
+    bash
+    tox
+    rename.sh
 deps =
     -r{toxinidir}/requirements.txt
 
 [testenv:build]
+basepython = python3
+deps = -r{toxinidir}/build-requirements.txt
+commands =
+    charmcraft clean
+    charmcraft -v build
+    {toxinidir}/rename.sh
+
+[testenv:build-reactive]
 basepython = python3
 commands =
     charm-build --log-level DEBUG --use-lock-file-branches -o {toxinidir}/build/builds src {posargs}
@@ -85,6 +98,18 @@ basepython = python3
 deps = flake8==3.9.2
        charm-tools==2.8.3
 commands = flake8 {posargs} src unit_tests
+
+[testenv:func-target]
+# Hack to get functional tests working in the charmcraft
+# world. We should fix this.
+basepython = python3
+passenv = HOME TERM CS_* OS_* TEST_*
+deps = -r{toxinidir}/src/test-requirements.txt
+changedir = {toxinidir}/src
+commands =
+  bash -c "if [ ! -f ../*.charm ]; then echo 'Charm does not exist. Run tox -e build'; exit 1; fi"
+  tox --version
+  tox -e func-target {posargs}
 
 [testenv:cover]
 # Technique based heavily upon


### PR DESCRIPTION
This patch to the global/source-zaza files is to enable a reactive charm
to be built by the CI system in the 'charm-build' job. This is so that
the charm will have to "charmcraft build" before doing tests and ensures
that it is at least buildable prior to being delivered to launchpad for
build and push to the charmhub.