### PR TITLE
Remove bionic from mysql-innodb-cluster lp config

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -38,9 +38,6 @@ projects:
       stable/focal:
         channels:
           - 8.0.19/edge
-      stable/bionic:
-        channels:
-          - 5.7/edge
 
   - name: MySQL Router
     charmhub: mysql-router
@@ -53,9 +50,6 @@ projects:
       stable/focal:
         channels:
           - 8.0.19/edge
-      stable/5.7:
-        channels:
-          - 5.7/edge
 
   - name: Percona Cluster Charm
     charmhub: percona-cluster


### PR DESCRIPTION
The bionic track was errantly included in the charmhub launchpad
configuration. This removes the bionic track, since only focal is
supported in the charm.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>