### PR TITLE
Scope magnum tracks and branches correctly

### DIFF
--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -324,11 +324,45 @@ projects:
     charmhub: magnum
     launchpad: charm-magnum
     repository: https://opendev.org/openstack/charm-magnum.git
+    branches:
+      master:
+        channels:
+          - latest/edge
+          - yoga/edge
+      stable/ussuri:
+        channels:
+          - ussuri/edge
+      stable/victoria:
+        channels:
+          - victoria/edge
+      stable/wallaby:
+        channels:
+          - wallaby/edge
+      stable/xena:
+        channels:
+          - xena/edge
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
     launchpad: charm-magnum-dashboard
     repository: https://opendev.org/openstack/charm-magnum-dashboard.git
+    branches:
+      master:
+        channels:
+          - latest/edge
+          - yoga/edge
+      stable/ussuri:
+        channels:
+          - ussuri/edge
+      stable/victoria:
+        channels:
+          - victoria/edge
+      stable/wallaby:
+        channels:
+          - wallaby/edge
+      stable/xena:
+        channels:
+          - xena/edge
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard


### PR DESCRIPTION
Scope the magnum tracks and branches to Ussuri+, as that is all the
charm supports.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>