### PR TITLE
Scope ceph-dashboard to Octopus and newer

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -31,6 +31,17 @@ projects:
     charmhub: ceph-dashboard
     launchpad: charm-ceph-dashboard
     repository: https://opendev.org/openstack/charm-ceph-dashboard.git
+    branches:
+      master:
+        channels:
+          - latest/edge
+          - quincy/edge
+      stable/octopus:
+        channels:
+          - octopus/edge
+      stable/pacific:
+        channels:
+          - pacific/edge
 
   - name: Ceph FileSystem Charm
     charmhub: ceph-fs


### PR DESCRIPTION
Ceph dashboard only supports octopus and newer. Let's scope it correctly
in the lp-builder-config tools.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>