### PR TITLE
Add ovn 22.03 track

### DIFF
--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -5,6 +5,7 @@ defaults:
     master:
       channels:
         - latest/edge
+        - 22.03/edge
     stable/20.03:
       channels:
         - openstack-ussuri/edge


### PR DESCRIPTION
The main branch is currently tracking OVN 22.03 which is also the
version going into Ubuntu Jammy.