### PR TITLE
Move openstack-loadbalancer to the misc section

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -107,3 +107,16 @@ projects:
       stable/1.5:
         channels:
           - 1.5/edge
+
+  - name: OpenStack Loadbalancer Charm
+    charmhub: openstack-loadbalancer
+    launchpad: charm-openstack-loadbalancer
+    repository: https://opendev.org/openstack/charm-openstack-loadbalancer.git
+    branches:
+      master:
+        channels:
+          - latest/edge
+          - jammy/edge
+      stable/focal:
+        channels:
+          - focal/edge

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -504,25 +504,3 @@ projects:
     charmhub: octavia-diskimage-retrofit
     launchpad: charm-octavia-diskimage-retrofit
     repository: https://opendev.org/openstack/charm-octavia-diskimage-retrofit.git
-
-  - name: OpenStack Loadbalancer Charm
-    charmhub: openstack-loadbalancer
-    launchpad: charm-openstack-loadbalancer
-    repository: https://opendev.org/openstack/charm-openstack-loadbalancer.git
-    branches:
-      master:
-        channels:
-          - latest/edge
-          - yoga/edge
-      stable/ussuri:
-        channels:
-          - ussuri/edge
-      stable/victoria:
-        channels:
-          - victoria/edge
-      stable/wallaby:
-        channels:
-          - wallaby/edge
-      stable/xena:
-        channels:
-          - xena/edge


### PR DESCRIPTION
The openstack-loadbalancer isn't actually an openstack service, but is
instead a loadbalancer for openstack projects.  As such, it's more like
rabbitmq-server or mysql-innodb-cluster and will have 'focal' and
'jammy' releases, that are aligned to the LTS releases that it runs on.

This PR moves them.  Note, this will affect upstream branches and tracks
on charmhub.