### PR TITLE
Pin cryptography<3.4

### DIFF
--- a/global/classic-zaza/requirements.txt
+++ b/global/classic-zaza/requirements.txt
@@ -11,6 +11,16 @@ pbr==5.6.0
 simplejson>=2.2.0
 netifaces>=0.10.4
 
+# Build requirements
+cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
+
+# NOTE: newer versions of cryptography require a Rust compiler to build,
+# see
+# * https://github.com/openstack-charmers/zaza/issues/421
+# * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
+#
+cryptography<3.4
+
 # Strange import error with newer netaddr:
 netaddr>0.7.16,<0.8.0
 

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -10,6 +10,14 @@ setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb
 
 # Build requirements
 cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
+
+# NOTE: newer versions of cryptography require a Rust compiler to build,
+# see
+# * https://github.com/openstack-charmers/zaza/issues/421
+# * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
+#
+cryptography<3.4
+
 charm-tools==2.8.3
 
 simplejson


### PR DESCRIPTION
cryptography>=3.4 requires a rust compiler.