### PR TITLE
Add missing releases to barbican-vault configuration

### DIFF
--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -57,6 +57,15 @@ projects:
         channels:
           - latest/edge
           - yoga/edge
+      stable/rocky:
+        channels:
+          - rocky/edge
+      stable/stein:
+        channels:
+          - stein/edge
+      stable/train:
+        channels:
+          - train/edge
       stable/ussuri:
         channels:
           - ussuri/edge


### PR DESCRIPTION
Releases Rocky through Train were missing from the barbican-vault
configuration for the lp-builder-configs.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>