### PR TITLE
Pin charmcraft to 1.5/stable

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -3,26 +3,38 @@ defaults:
   team: openstack-charmers
   branches:
     master:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - latest/edge
         - quincy/edge
     stable/luminous:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-queens/edge
         - openstack-rocky/edge
         - luminous/edge
     stable/mimic:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-stein/edge
         - mimic/edge
     stable/nautilus:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-train/edge
         - nautilus/edge
     stable/octopus:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - octopus/edge
     stable/pacific:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - pacific/edge
 
@@ -33,13 +45,19 @@ projects:
     repository: https://opendev.org/openstack/charm-ceph-dashboard.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - quincy/edge
       stable/octopus:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - octopus/edge
       stable/pacific:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - pacific/edge
 

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -9,12 +9,18 @@ projects:
     repository: https://opendev.org/openstack/charm-hacluster.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 2.0.3/edge
       stable/bionic:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 1.1.18/edge
 
@@ -24,6 +30,8 @@ projects:
     repository: https://opendev.org/openstack/charm-magpie.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
 
@@ -33,9 +41,13 @@ projects:
     repository: https://opendev.org/openstack/charm-mysql-innodb-cluster.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 8.0.19/edge
 
@@ -45,9 +57,13 @@ projects:
     repository: https://opendev.org/openstack/charm-mysql-router.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 8.0.19/edge
 
@@ -57,9 +73,13 @@ projects:
     repository: https://opendev.org/openstack/charm-percona-cluster.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/bionic:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 5.7/edge
 
@@ -69,13 +89,19 @@ projects:
     repository: https://opendev.org/openstack/charm-rabbitmq-server.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           #- 3.9/edge
       stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 3.8/edge
       stable/bionic:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 3.6/edge
 
@@ -86,6 +112,8 @@ projects:
     repository: https://github.com/openstack-charmers/charm-woodpecker
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
 
@@ -96,15 +124,23 @@ projects:
     repository: https://opendev.org/openstack/charm-vault.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/1.7:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 1.7/edge
       stable/1.6:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 1.6/edge
       stable/1.5:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - 1.5/edge
 
@@ -114,9 +150,13 @@ projects:
     repository: https://opendev.org/openstack/charm-openstack-loadbalancer.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - jammy/edge
       stable/focal:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - focal/edge

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -3,31 +3,49 @@ defaults:
   team: openstack-charmers
   branches:
     master:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - latest/edge
         - yoga/edge
     stable/queens:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - queens/edge
     stable/rocky:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - rocky/edge
     stable/stein:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - stein/edge
     stable/train:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - train/edge
     stable/ussuri:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - ussuri/edge
     stable/victoria:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - victoria/edge
     stable/wallaby:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - wallaby/edge
     stable/xena:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - xena/edge
 
@@ -54,28 +72,44 @@ projects:
     repository: https://opendev.org/openstack/charm-barbican-vault.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/rocky:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - rocky/edge
       stable/stein:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - stein/edge
       stable/train:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -241,22 +275,34 @@ projects:
     repository: https://opendev.org/openstack/charm-placement.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/train:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -315,19 +361,29 @@ projects:
     repository: https://opendev.org/openstack/charm-cinder-nimblestorage.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -337,19 +393,29 @@ projects:
     repository: https://opendev.org/openstack/charm-cinder-solidfire.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -364,22 +430,34 @@ projects:
     repository: https://opendev.org/openstack/charm-ironic-api.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/train:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -389,22 +467,34 @@ projects:
     repository: https://opendev.org/openstack/charm-ironic-conductor.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/train:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -424,19 +514,29 @@ projects:
     repository: https://opendev.org/openstack/charm-magnum.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -446,19 +546,29 @@ projects:
     repository: https://opendev.org/openstack/charm-magnum-dashboard.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -483,22 +593,34 @@ projects:
     repository: https://opendev.org/openstack/charm-neutron-api-plugin-ironic.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/train:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 
@@ -508,19 +630,29 @@ projects:
     repository: https://opendev.org/openstack/charm-neutron-api-plugin-ovn.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
           - yoga/edge
       stable/ussuri:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
       stable/xena:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - xena/edge
 

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -3,19 +3,27 @@ defaults:
   team: openstack-charmers
   branches:
     master:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - latest/edge
         - 22.03/edge
     stable/20.03:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-ussuri/edge
         - openstack-victoria/edge
         - 20.03/edge
     stable/20.12:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-wallaby/edge
         - 20.12/edge
     stable/21.09:
+      build-channels:
+        charmcraft: "1.5/stable"
       channels:
         - openstack-xena/edge
         - 21.09/edge


### PR DESCRIPTION
charmcraft 1.6 renamed the environment variable from CHARMCRAFT_STAGE to
CRAFT_STAGE breaking charms building.

https://github.com/canonical/craft-parts/commit/6c18447497897794dc9ea86f164fb21c035f12d1