### PR TITLE
Changes to lp-builder-config for 22.04 release

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -7,25 +7,29 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - latest/edge
+    stable/quincy:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
         - quincy/edge
     stable/luminous:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-queens/edge
-        - openstack-rocky/edge
+        #- openstack-queens/edge
+        #- openstack-rocky/edge
         - luminous/edge
     stable/mimic:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-stein/edge
+        #- openstack-stein/edge
         - mimic/edge
     stable/nautilus:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-train/edge
+        #- openstack-train/edge
         - nautilus/edge
     stable/octopus:
       build-channels:
@@ -49,6 +53,10 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
+    stable/quincy:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
           - quincy/edge
       stable/octopus:
         build-channels:

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -13,6 +13,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
+      stable/jammy:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - 2.4/edge
       stable/focal:
         build-channels:
           charmcraft: "1.5/stable"
@@ -45,10 +50,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-      stable/focal:
+      stable/8.0:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
+          # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
           - 8.0.19/edge
 
   - name: MySQL Router
@@ -61,10 +67,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-      stable/focal:
+      stable/8.0:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
+          # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
           - 8.0.19/edge
 
   - name: Percona Cluster Charm
@@ -77,7 +84,7 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-      stable/bionic:
+      stable/5.7:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -93,13 +100,20 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          #- 3.9/edge
-      stable/focal:
+      # jammy
+      stable/3.9:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - 3.9/edge
+      # focal
+      stable/3.8:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 3.8/edge
-      stable/bionic:
+      # bionic
+      stable/3.6:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -153,7 +167,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - latest/edge
+          #- latest/edge
           - jammy/edge
       stable/focal:
         build-channels:

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -167,7 +167,11 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          #- latest/edge
+          - latest/edge
+      stable/jammy:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
           - jammy/edge
       stable/focal:
         build-channels:

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -7,7 +7,6 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - latest/edge
-        - yoga/edge
     stable/queens:
       build-channels:
         charmcraft: "1.5/stable"
@@ -48,6 +47,11 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - xena/edge
+    stable/yoga:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - yoga/edge
 
 projects:
   - name: OpenStack Aodh Charm
@@ -76,7 +80,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/rocky:
         build-channels:
           charmcraft: "1.5/stable"
@@ -112,6 +115,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -279,7 +287,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/train:
         build-channels:
           charmcraft: "1.5/stable"
@@ -305,6 +312,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
 #  - name: OpenStack Tempest Charm
 #    charmhub: tempest
@@ -365,7 +377,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/ussuri:
         build-channels:
           charmcraft: "1.5/stable"
@@ -386,6 +397,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -397,7 +413,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/ussuri:
         build-channels:
           charmcraft: "1.5/stable"
@@ -418,6 +433,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -434,7 +454,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/train:
         build-channels:
           charmcraft: "1.5/stable"
@@ -460,6 +479,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -471,7 +495,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/train:
         build-channels:
           charmcraft: "1.5/stable"
@@ -497,6 +520,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -518,7 +546,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/ussuri:
         build-channels:
           charmcraft: "1.5/stable"
@@ -539,6 +566,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -550,7 +582,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/ussuri:
         build-channels:
           charmcraft: "1.5/stable"
@@ -571,6 +602,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -597,7 +633,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/train:
         build-channels:
           charmcraft: "1.5/stable"
@@ -623,6 +658,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -634,7 +674,6 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-          - yoga/edge
       stable/ussuri:
         build-channels:
           charmcraft: "1.5/stable"
@@ -655,6 +694,11 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - xena/edge
+      stable/yoga:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/edge
 
   # - name: OpenStack Neutron Dynamic Routing Charm
   #  charmhub: neutron-dynamic-routing

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -7,25 +7,29 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - latest/edge
+    stable/22.03:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
         - 22.03/edge
     stable/20.03:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-ussuri/edge
-        - openstack-victoria/edge
+        #- openstack-ussuri/edge
+        #- openstack-victoria/edge
         - 20.03/edge
     stable/20.12:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-wallaby/edge
+        #- openstack-wallaby/edge
         - 20.12/edge
     stable/21.09:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - openstack-xena/edge
+        #- openstack-xena/edge
         - 21.09/edge
 
 projects:


### PR DESCRIPTION
This is mainly moving channels to the stable/yoga, stable/22.04
and stable/quincy tracks for openstack, ovn and ceph charms.  The
misc charms are handled a little differently, in that charms need to
span two LTS (for series upgrade), but also try to track the major
version number of the payload.