### PR TITLE
Switch recent stable releases to <track>/stable

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -11,8 +11,9 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - quincy/edge
+        - quincy/stable
     stable/luminous:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -20,23 +21,27 @@ defaults:
         #- openstack-rocky/edge
         - luminous/edge
     stable/mimic:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         #- openstack-stein/edge
         - mimic/edge
     stable/nautilus:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         #- openstack-train/edge
         - nautilus/edge
     stable/octopus:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - octopus/edge
     stable/pacific:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -53,17 +58,19 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-    stable/quincy:
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-          - quincy/edge
+      stable/quincy:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+            - quincy/stable
       stable/octopus:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
       stable/pacific:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -90,12 +97,19 @@ projects:
     repository: https://opendev.org/openstack/charm-ceph-nfs.git
     branches:
       master:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       stable/quincy:
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
       stable/pacific:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
         channels:
           - pacific/edge
 

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -17,13 +17,14 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 2.4/edge
+          - 2.4/stable
       stable/focal:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 2.0.3/edge
+          - 2.0.3/stable
       stable/bionic:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -50,12 +51,13 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-      stable/8.0:
+      #stable/8.0:
+      stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
-          - 8.0.19/edge
+          - 8.0.19/stable
 
   - name: MySQL Router
     charmhub: mysql-router
@@ -67,12 +69,13 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
-      stable/8.0:
+      #stable/8.0:
+      stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
-          - 8.0.19/edge
+          - 8.0.19/stable
 
   - name: Percona Cluster Charm
     charmhub: percona-cluster
@@ -85,6 +88,7 @@ projects:
         channels:
           - latest/edge
       stable/5.7:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -101,19 +105,23 @@ projects:
         channels:
           - latest/edge
       # jammy
-      stable/3.9:
+      #stable/3.9:
+      stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 3.9/edge
+          - 3.9/stable
       # focal
-      stable/3.8:
+      #stable/3.8:
+      stable/focal:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 3.8/edge
-      # bionic
+      # bionic - not enabled yet
       stable/3.6:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -146,17 +154,17 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 1.7/edge
+          - 1.7/stable
       stable/1.6:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 1.6/edge
+          - 1.6/stable
       stable/1.5:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 1.5/edge
+          - 1.5/stable
 
   - name: OpenStack Loadbalancer Charm
     charmhub: openstack-loadbalancer
@@ -172,8 +180,9 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - jammy/edge
+          - jammy/stable
       stable/focal:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -8,36 +8,43 @@ defaults:
       channels:
         - latest/edge
     stable/queens:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - queens/edge
     stable/rocky:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - rocky/edge
     stable/stein:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - stein/edge
     stable/train:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - train/edge
     stable/ussuri:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - ussuri/edge
     stable/victoria:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - victoria/edge
     stable/wallaby:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -51,7 +58,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - yoga/edge
+        - yoga/stable
 
 projects:
   - name: OpenStack Aodh Charm
@@ -81,31 +88,37 @@ projects:
         channels:
           - latest/edge
       stable/rocky:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - rocky/edge
       stable/stein:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - stein/edge
       stable/train:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -119,7 +132,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -293,21 +306,25 @@ projects:
         channels:
           - latest/edge
       stable/train:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -321,7 +338,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
 #  - name: OpenStack Tempest Charm
 #    charmhub: tempest
@@ -383,16 +400,19 @@ projects:
         channels:
           - latest/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -406,7 +426,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -419,16 +439,19 @@ projects:
         channels:
           - latest/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -442,7 +465,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -460,21 +483,25 @@ projects:
         channels:
           - latest/edge
       stable/train:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -488,7 +515,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -501,21 +528,25 @@ projects:
         channels:
           - latest/edge
       stable/train:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -529,7 +560,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -552,16 +583,19 @@ projects:
         channels:
           - latest/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -575,7 +609,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -588,16 +622,19 @@ projects:
         channels:
           - latest/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -611,7 +648,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -639,21 +676,25 @@ projects:
         channels:
           - latest/edge
       stable/train:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -667,7 +708,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -680,16 +721,19 @@ projects:
         channels:
           - latest/edge
       stable/ussuri:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
       stable/victoria:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
       stable/wallaby:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -703,7 +747,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - yoga/edge
+          - yoga/stable
 
   # - name: OpenStack Neutron Dynamic Routing Charm
   #  charmhub: neutron-dynamic-routing

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -11,8 +11,9 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - 22.03/edge
+        - 22.03/stable
     stable/20.03:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -20,12 +21,14 @@ defaults:
         #- openstack-victoria/edge
         - 20.03/edge
     stable/20.12:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         #- openstack-wallaby/edge
         - 20.12/edge
     stable/21.09:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:


### PR DESCRIPTION
This is inline with the current policy where a stable backport receives
two +2s on Gerrit and then is immediately pushed to the stable branch.
The stable branches are:

 - yoga/stable
 - quincy/stable
 - 22.03/stable
 - various for the misc charms (see patch)

Also, added an 'enabled: False' key for branches that have not yet been
enabled so that the tool can ignore them unless they are specifically
mentioned.