### PR TITLE
Add libpq-dev to the charmcraft-build-lock-file.yaml

### DIFF
--- a/global/source-zaza/charmcraft-build-lock-file.yaml
+++ b/global/source-zaza/charmcraft-build-lock-file.yaml
@@ -11,6 +11,7 @@ parts:
       - libxml2-dev
       - libxslt1-dev
       - libmysqlclient-dev  # for executable mysql_shell 
+      - libpq-dev  # for the `pg_config` executable
     override-build: |
       apt-get install ca-certificates -y
       tox -e add-build-lock-file


### PR DESCRIPTION
This 'generic' charmcraft.yaml is used to create build.lock files, and
the additional library (libpq-dev) is required for the vault charm as
part of the build process.