### PR TITLE
Use charm-tools from the git repo.

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -84,7 +84,7 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8==3.9.2
-       charm-tools==2.8.3
+       git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
            charm-proof
 

--- a/global/source-zaza/requirements.txt
+++ b/global/source-zaza/requirements.txt
@@ -18,7 +18,8 @@ cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
 #
 cryptography<3.4
 
-charm-tools==2.8.3
+charm-tools==2.8.3; python_version < '3.10'
+git+https://github.com/juju/charm-tools.git; python_version >= '3.10'
 
 simplejson
 

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -96,7 +96,7 @@ commands = stestr run --slowest {posargs}
 [testenv:pep8]
 basepython = python3
 deps = flake8==3.9.2
-       charm-tools==2.8.3
+       git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} src unit_tests
 
 [testenv:func-target]


### PR DESCRIPTION
charm-tools gained support for python 3.10 in master[0] and most
importantly the pinning of dependencies were lifted which allows the
correct installation of packages like ruamel.yaml.

[0] https://github.com/juju/charm-tools/pull/614