### PR TITLE
Update mysql channel names to 8.0

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -56,8 +56,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
-          - 8.0.19/stable
+          - 8.0/stable
 
   - name: MySQL Router
     charmhub: mysql-router
@@ -74,8 +73,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          # - rename this one to 8.0 when we can do an alias from 8.0.19 -> 8.0
-          - 8.0.19/stable
+          - 8.0/stable
 
   - name: Percona Cluster Charm
     charmhub: percona-cluster


### PR DESCRIPTION
As we've learned, going down to a minor version number is less than
ideal for channel names when pulling from the archives. This changes
the channel name for mysql-innodb-cluster and mysql-router from 8.0.19
to 8.0.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>