### PR TITLE
Charmcraft 1.6 support.

### DIFF
--- a/global/source-zaza/charmcraft-build-lock-file.yaml
+++ b/global/source-zaza/charmcraft-build-lock-file.yaml
@@ -10,20 +10,23 @@ parts:
       - libssl-dev
       - libxml2-dev
       - libxslt1-dev
-      - libmysqlclient-dev  # for executable mysql_shell 
+      - libmysqlclient-dev  # for executable mysql_shell
       - libpq-dev  # for the `pg_config` executable
     override-build: |
       apt-get install ca-certificates -y
       tox -e add-build-lock-file
     override-stage: |
-      echo "Copying charm to staging area: $CHARMCRAFT_STAGE"
-      NAME=$(ls $CHARMCRAFT_PART_BUILD/build/builds)
-      cp -r $CHARMCRAFT_PART_BUILD/build/builds/$NAME/* $CHARMCRAFT_STAGE/
-      cp $CHARMCRAFT_PART_BUILD/src/build.lock $CHARMCRAFT_STAGE/build.lock
+      STAGE_DIR=${CRAFT_STAGE:-$CHARMCRAFT_STAGE}
+      BUILD_DIR=${CRAFT_PART_BUILD:-$CHARMCRAFT_PART_BUILD}
+
+      echo "Copying charm to staging area: $STAGE_DIR"
+      NAME=$(ls $BUILD_DIR/build/builds)
+      cp -r $BUILD_DIR/build/builds/$NAME/* $STAGE_DIR/
     override-prime: |
       # For some reason, the normal priming chokes on the fact that there's a
       # hooks directory.
-      cp -r $CHARMCRAFT_STAGE/* .
+      STAGE_DIR=${CRAFT_STAGE:-$CHARMCRAFT_STAGE}
+      cp -r $STAGE_DIR/* .
 
 bases:
   - build-on:

--- a/global/source-zaza/charmcraft.yaml
+++ b/global/source-zaza/charmcraft.yaml
@@ -10,13 +10,17 @@ parts:
       apt-get install ca-certificates -y
       tox -e build-reactive
     override-stage: |
-      echo "Copying charm to staging area: $CHARMCRAFT_STAGE"
-      NAME=$(ls $CHARMCRAFT_PART_BUILD/build/builds)
-      cp -r $CHARMCRAFT_PART_BUILD/build/builds/$NAME/* $CHARMCRAFT_STAGE/
+      STAGE_DIR=${CRAFT_STAGE:-$CHARMCRAFT_STAGE}
+      BUILD_DIR=${CRAFT_PART_BUILD:-$CHARMCRAFT_PART_BUILD}
+
+      echo "Copying charm to staging area: $STAGE_DIR"
+      NAME=$(ls $BUILD_DIR/build/builds)
+      cp -r $BUILD_DIR/build/builds/$NAME/* $STAGE_DIR/
     override-prime: |
       # For some reason, the normal priming chokes on the fact that there's a
       # hooks directory.
-      cp -r $CHARMCRAFT_STAGE/* .
+      STAGE_DIR=${CRAFT_STAGE:-$CHARMCRAFT_STAGE}
+      cp -r $STAGE_DIR/* .
 
 bases:
   - name: ubuntu


### PR DESCRIPTION
This change uses new CRAFT_* environment variables defined when using
charmcraft-1.6, if they are not set, then it falls back to CHARMCRAFT_*.