### PR TITLE
Remove outdated references to files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ File | Purpose / Note
 :--- | :---
 ```bug-link-overrides```    | A list of exceptions and overrides for charm bug trackers that deviate from the usual URL structure.
 ```build-charm```           | Build src charms, enforce certain file and directory expectations.  Used by OSCI during tests.  Called by ```push-and-release``` as needed.
-```charms.txt```            | The master list of all OpenStack charms which are subject to pushing/releasing via the git, gerrit, charm store flow.
 ```check-repo-links```      | Check the repo links
 ```check-bug-links```       | Check the bug links
 ```check-series```          | A crude check for LTS series presence in charm metadata.  It is not gating, just informational.
@@ -18,7 +17,6 @@ File | Purpose / Note
 ```push-and-release```      | Used by OSCI automation to build, push and release charms after changes are merged and changed at the github repos.
 ```release-stable-charms``` | Do a new STABLE RELEASE from MASTER for all charms.
 ```repo-link-overrides```   | A list of exceptions and overrides for charm repos that deviate from the usual URL structure.
-```source-charms.txt```     | Master list of 'source charms,' used by ```update-tox-files```.
 ```stable-branch-updates``` | Post-Release Repo Tasks: Flip stable charm-helpers and Zaza bits;  Update .gitreview with new stable branch name. Called by ```update-stable-charms```.
 ```update-stable-charms```  | Applies stable-branch-updates to all charms.
 ```./DEPRECATED_SAVE_EXAMPLES/```         | Bone yard of old scripts which may or may not be useful or dangerous.


### PR DESCRIPTION
These *charms.txt files were removed in commit 36c8f3.