### PR TITLE
Clean after building a charm.

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -50,6 +50,7 @@ commands =
     charmcraft clean
     charmcraft -v build
     {toxinidir}/rename.sh
+    charmcraft clean
 
 [testenv:py35]
 basepython = python3.5

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -52,6 +52,7 @@ commands =
     charmcraft clean
     charmcraft -v build
     {toxinidir}/rename.sh
+    charmcraft clean
 
 [testenv:build-reactive]
 basepython = python3


### PR DESCRIPTION
Running `charmcraft clean` at the end of the `build` target prevents
from littering the system with containers that won't be reused since
before running `charmcraft pack` the command `charmcraft clean` is
executed.