### PR TITLE
Pin charmcraft to 1.7/stable

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "1.5/stable"
+        charmcraft: "1.7/stable"
       channels:
         - latest/edge
     stable/quincy:
@@ -55,7 +55,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/quincy:
@@ -98,7 +98,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/quincy:

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -10,7 +10,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/jammy:
@@ -37,7 +37,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
 
@@ -48,7 +48,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       #stable/8.0:
@@ -65,7 +65,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       #stable/8.0:
@@ -82,7 +82,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/5.7:
@@ -99,7 +99,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       # jammy
@@ -133,7 +133,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
 
@@ -145,14 +145,14 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
-      stable/1.7:
+      stable/1.5:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 1.7/stable
+          - 1.5/stable
       stable/1.6:
         build-channels:
           charmcraft: "1.5/stable"
@@ -171,7 +171,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/jammy:

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "1.5/stable"
+        charmcraft: "1.7/stable"
       channels:
         - latest/edge
     stable/queens:
@@ -84,7 +84,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/rocky:
@@ -302,7 +302,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/train:
@@ -396,7 +396,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/ussuri:
@@ -435,7 +435,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/ussuri:
@@ -479,7 +479,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/train:
@@ -524,7 +524,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/train:
@@ -579,7 +579,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/ussuri:
@@ -618,7 +618,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/ussuri:
@@ -672,7 +672,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/train:
@@ -717,7 +717,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
       stable/ussuri:

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "1.5/stable"
+        charmcraft: "1.7/stable"
       channels:
         - latest/edge
     stable/22.03:

--- a/lp-builder-config/trilio.yaml
+++ b/lp-builder-config/trilio.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "1.5/stable"
+        charmcraft: "1.7/stable"
       channels:
         - latest/edge
     stable/4.0:


### PR DESCRIPTION
Switch from 1.5/stable to 1.7/stable to get 22.04 support.