### PR TITLE
Use 'charmcraft pack'

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -48,7 +48,7 @@ basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
 commands =
     charmcraft clean
-    charmcraft -v build
+    charmcraft -v pack
     {toxinidir}/rename.sh
 
 [testenv:py35]

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -50,7 +50,7 @@ basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
 commands =
     charmcraft clean
-    charmcraft -v build
+    charmcraft -v pack
     {toxinidir}/rename.sh
 
 [testenv:build-reactive]


### PR DESCRIPTION
charmcraft 2.0 dropped the 'build' target in favor of 'pack' which
was deprecated in 1.5[0].

[0] https://juju.is/docs/sdk/charmcraft-deprecations#heading--dn06