### PR TITLE
[xena|pacific|21.09]/stable release

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -45,7 +45,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - pacific/edge
+        - pacific/stable
 
 projects:
   - name: Ceph Dashboard Charm
@@ -74,7 +74,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - pacific/edge
+          - pacific/stable
 
   - name: Ceph FileSystem Charm
     charmhub: ceph-fs

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -116,7 +116,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - 3.8/edge
+          - 3.8/stable
       # bionic - not enabled yet
       stable/3.6:
         enabled: False

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -53,7 +53,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - xena/edge
+        - xena/stable
     stable/yoga:
       build-channels:
         charmcraft: "1.5/stable"
@@ -127,7 +127,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -333,7 +333,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -421,7 +421,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -460,7 +460,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -510,7 +510,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -555,7 +555,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -604,7 +604,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -643,7 +643,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -703,7 +703,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"
@@ -742,7 +742,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - xena/edge
+          - xena/stable
       stable/yoga:
         build-channels:
           charmcraft: "1.5/stable"

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -33,7 +33,7 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         #- openstack-xena/edge
-        - 21.09/edge
+        - 21.09/stable
 
 projects:
   - name: OVN Central


### PR DESCRIPTION
Update the channel targets for the OpenStack, Ceph and OVN charms
following the Xena stable (and associated charms, releases)