### PR TITLE
Remove charmcraft clean from tox build target

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -47,7 +47,6 @@ deps = -r{toxinidir}/test-requirements.txt
 basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
 commands =
-    charmcraft clean
     charmcraft -v pack
     {toxinidir}/rename.sh
 

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -49,7 +49,6 @@ deps =
 basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
 commands =
-    charmcraft clean
     charmcraft -v pack
     {toxinidir}/rename.sh
 


### PR DESCRIPTION
This is unnecessary, and slows down rebuilds.
