### PR TITLE
Include custom scripts in allowlist_externals

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -39,7 +39,8 @@ install_command =
 commands = stestr run --slowest {posargs}
 allowlist_externals =
     charmcraft
-    rename.sh
+    {toxinidir}/rename.sh
+    {toxinidir}/pip.sh
 passenv = HOME TERM CS_* OS_* TEST_*
 deps = -r{toxinidir}/test-requirements.txt
 

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -41,7 +41,8 @@ allowlist_externals =
     charmcraft
     bash
     tox
-    rename.sh
+    {toxinidir}/rename.sh
+    {toxinidir}/pip.sh
 deps =
     -r{toxinidir}/requirements.txt
 


### PR DESCRIPTION
rename.sh and pip.sh are invoked using their absolute paths and that's
what needs to be included in the allowlist_externals config key.