### PR TITLE
Add openidc-test-fixture to lp-builder-config

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -185,3 +185,14 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - focal/edge
+
+  - name: OpenID Connect Test Fixture Charm
+    charmhub: openidc-test-fixture
+    launchpad: charm-openidc-test-fixture
+    repository: https://github.com/openstack-charmers/charm-openidc-test-fixture.git
+    branches:
+      main:
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - latest/edge


### PR DESCRIPTION
The charm openidc-test-fixture is meant to be used for testing keystone-openidc charm.