### PR TITLE
Add keystone-openidc

### DIFF
--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -651,6 +651,17 @@ projects:
     launchpad: charm-keystone-kerberos
     repository: https://opendev.org/openstack/charm-keystone-kerberos.git
 
+  - name: OpenStack Keystone OpenID Connect
+    charmhub: keystone-openidc
+    launchpad: charm-keystone-openidc
+    repository: https://opendev.org/openstack/charm-keystone-openidc.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - latest/edge
+
   - name: OpenStack Keystone SAML Mellon Charm
     charmhub: keystone-saml-mellon
     launchpad: charm-keystone-saml-mellon


### PR DESCRIPTION
Register keystone-openidc in lp-builder-config. The only branch that exists at the moment is master, hence latest/edge track/risk is defined.