### PR TITLE
Drop duplicated entry of cinder-purestorage

### DIFF
--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -159,11 +159,6 @@ projects:
     launchpad: charm-cinder-ceph
     repository: https://opendev.org/openstack/charm-cinder-ceph.git
 
-  - name: OpenStack Cinder Purestorage Charm
-    charmhub: cinder-purestorage
-    launchpad: charm-cinder-purestorage
-    repository: https://opendev.org/openstack/charm-cinder-purestorage.git
-
   - name: OpenStack Dashboard Charm
     charmhub: openstack-dashboard
     launchpad: charm-openstack-dashboard


### PR DESCRIPTION
The commit 09890e81 introduced an entry for cinder-purestorage that lists explicitly the git branches that need to be used to create recipes, making this entry obsolete.