### PR TITLE
Move the pacemaker-remote charm to the misc section

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -196,3 +196,33 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+
+  - name: Pacemaker Remote Charm
+    charmhub: pacemaker-remote
+    launchpad: charm-pacemaker-remote
+    repository: https://opendev.org/openstack/charm-pacemaker-remote.git
+    branches:
+      master:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - latest/edge
+      stable/bionic:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - bionic/edge
+      stable/focal:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - focal/edge
+      stable/jammy:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - jammy/edge

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -235,36 +235,6 @@ projects:
     launchpad: charm-masakari-monitors
     repository: https://opendev.org/openstack/charm-masakari-monitors.git
 
-  - name: Pacemaker Remote Charm
-    charmhub: pacemaker-remote
-    launchpad: charm-pacemaker-remote
-    repository: https://opendev.org/openstack/charm-pacemaker-remote.git
-    branches:
-      master:
-        enabled: True
-        build-channels:
-          charmcraft: "2.0/stable"
-        channels:
-          - latest/edge
-      stable/bionic:
-        enabled: True
-        build-channels:
-          charmcraft: "1.5/stable"
-        channels:
-          - bionic/edge
-      stable/focal:
-        enabled: True
-        build-channels:
-          charmcraft: "1.5/stable"
-        channels:
-          - focal/edge
-      stable/jammy:
-        enabled: True
-        build-channels:
-          charmcraft: "1.5/stable"
-        channels:
-          - jammy/edge
-
 #  - name: OpenStack Mistral Charm
 #    charmhub: mistral
 #    launchpad: charm-mistral


### PR DESCRIPTION
Move the pacemaker-remote charm configuration to the misc section as it doesn't follow the OpenStack charms' release names, but is instead distro specific.