### PR TITLE
Updates to release-tools during the zed stable/branch cuts

### DIFF
--- a/get-build-lock
+++ b/get-build-lock
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# param 1 should be the name of the charm
+# param 2 should be where to put it (default src/build.lock)
+
+charm=$1
+dest=${2:-src/build.lock}
+
+# find the container name
+match="^charmcraft-$charm-[0-9]"
+line=$(lxc list --project charmcraft --format csv | grep -e "$match")
+container=$(echo $line | cut -d, -f1)
+echo "container is '$container'"
+
+if [ -z $container ];
+then
+    echo "Can't find $charm?"
+    exit 1
+fi
+
+if [[ "$line" == *"STOPPED"* ]];
+then
+    lxc start --project charmcraft $container
+    echo "Started $container"
+fi
+
+file=$(lxc exec --project charmcraft $container -- find /root -name 'build.lock' | head -n1 | tr -d '\n')
+echo "file is '$file'"
+
+if [ -z $file ];
+then
+    echo "Couldn't find build.lock!"
+    exit 1
+fi
+
+lxc file pull --project charmcraft "$container$file" $dest
+echo "copied file."
+

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -63,6 +63,12 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - yoga/stable
+    stable/zed:
+      enabled: True
+      build-channels:
+        charmcraft: "2.0/stable"
+      channels:
+        - zed/edge
 
 projects:
   - name: OpenStack Aodh Charm
@@ -139,6 +145,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -343,6 +355,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
 #  - name: OpenStack Tempest Charm
 #    charmhub: tempest
@@ -434,6 +452,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Cinder Purestorage Charm
     charmhub: cinder-purestorage
@@ -482,6 +506,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -524,6 +554,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -571,6 +607,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Ironic API Charm
     charmhub: ironic-api
@@ -619,6 +661,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -667,6 +715,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -684,6 +738,12 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Keystone SAML Mellon Charm
     charmhub: keystone-saml-mellon
@@ -731,6 +791,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -773,6 +839,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -836,6 +908,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -878,6 +956,12 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
 
   # - name: OpenStack Neutron Dynamic Routing Charm
   #  charmhub: neutron-dynamic-routing

--- a/set-zed-bundles
+++ b/set-zed-bundles
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# run this script in the root of the charm directory
+
+script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd)"
+repo_dir="$script_dir/.."
+ceph_release="quincy"
+openstack_release="zed"
+ubuntu_release="jammy"
+ovn_release="22.09"
+vault_release="1.8"
+
+
+function update_bundles {
+    local charm_dir=$1
+    (
+        cd $charm_dir
+        $script_dir/update-channel-single.py --log DEBUG \
+            --branch stable/$openstack_release \
+            --branch stable/$ovn_release \
+            --branch stable/$ubuntu_release \
+            --branch stable/1.8 \
+            --branch stable/$ceph_release \
+            --enforce-edge
+    )
+}
+
+# Note that this needs to be run in the root for the charm directory
+update_bundles .

--- a/shell-into
+++ b/shell-into
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# param 1 should be the name of the charm
+
+charm=$1
+
+# find the container name
+match="^charmcraft-$charm-[0-9]"
+line=$(lxc list --project charmcraft --format csv | grep -e "$match")
+container=$(echo $line | cut -d, -f1)
+echo "container is '$container'"
+
+if [ -z $container ];
+then
+    echo "Can't find $charm?"
+    exit 1
+fi
+
+if [[ "$line" == *"STOPPED"* ]];
+then
+    lxc start --project charmcraft $container
+    echo "Started $container"
+fi
+
+lxc shell --project charmcraft $container
+

--- a/stable-branch-updates
+++ b/stable-branch-updates
@@ -16,7 +16,19 @@ if [ -z "$branch" ]; then
 fi
 
 git fetch --all
-git checkout -b ${release}-updates origin/stable/${branch}
+
+# relies on openstack_release being passed as var 1 and branch in var 2
+function ensure_git_branch {
+    local release=$1
+    local branch=$2
+    local current_branch=$(git branch --show-current | tr -d '\n')
+    if [[ "$current_branch" != "${release}-updates" ]];
+    then
+        git checkout -b ${release}-updates origin/stable/${branch}
+    fi
+}
+
+ensure_git_branch ${release} ${branch}
 
 grep -q defaultbranch .gitreview || {
     echo -e "\ndefaultbranch=stable/$branch" >> .gitreview


### PR DESCRIPTION
These updates were done to help with working with the release-tools during the stable/zed branch cuts and first commits.  They are:

 * get-build-lock - extract a build.lock file from a LXD container that was used to write the lock-file.
 * shell-into - helper script to shell into an LXD container using the charm name.  Useful to get into the container to actually run `charm build --write-lock-file .` in the /root/parts/charm/src directory.
 * set-zed-bundles - the script used to write the modifications to the bundles for the stable/zed branch of each charm.
 * update-channel-single.py - modification to ensure that the 'edge' risk can be selected regardless of what the lp-build-config is configured as a channel mapping for a branch of a charm.
 * lp-builder-config/openstack.yaml - modifications to the recipes to support the stable/zed branch.