### PR TITLE
Add informational comments to tox build target

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -46,6 +46,10 @@ deps = -r{toxinidir}/test-requirements.txt
 [testenv:build]
 basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
+# charmcraft clean is done to ensure that
+# `tox -e build` always performs a clean, repeatable build.
+# For faster rebuilds during development,
+# directly run `charmcraft -v pack && ./rename.sh`.
 commands =
     charmcraft clean
     charmcraft -v pack

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -48,6 +48,10 @@ deps =
 [testenv:build]
 basepython = python3
 deps = -r{toxinidir}/build-requirements.txt
+# charmcraft clean is done to ensure that
+# `tox -e build` always performs a clean, repeatable build.
+# For faster rebuilds during development,
+# directly run `charmcraft -v pack && ./rename.sh`.
 commands =
     charmcraft clean
     charmcraft -v pack


### PR DESCRIPTION
Make the implicit information explicit,
regarding why charmcraft clean is used in the default build target,
and a suggestion for rebuilding faster if necessary.

ref https://github.com/openstack-charmers/release-tools/pull/250#pullrequestreview-1142586794
