### PR TITLE
Bump charmcraft to 2.0 for diskimage-retrofit charm

### DIFF
--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -1198,6 +1198,6 @@ projects:
       stable/yoga:
         enabled: True
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "2.0/stable"
         channels:
           - yoga/stable


### PR DESCRIPTION
The octavia-diskimage-retrofit charmcraft for yoga now requires 2.0/stable so bump this in the config.