### PR TITLE
Use charmcraft 1.5 in mysql-router master

### DIFF
--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -65,7 +65,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
       #stable/8.0:


### PR DESCRIPTION
The mysql-router charm, at the moment, uses charmcraft 1.5 for its
building, their charmcraft.yaml[0] relies on the environment variables
$CHARMCRAFT_* that were dropped after 1.5

[0] https://opendev.org/openstack/charm-mysql-router/src/branch/master/charmcraft.yaml#L14
