### PR TITLE
Trilio 4.2 is moving to binary builds

### DIFF
--- a/lp-builder-config/trilio.yaml
+++ b/lp-builder-config/trilio.yaml
@@ -19,7 +19,7 @@ defaults:
         - 4.1/stable
     stable/4.2:
       build-channels:
-        charmcraft: "1.5/stable"
+        charmcraft: "2.0/stable"
       channels:
         - 4.2/stable
 


### PR DESCRIPTION
Bump charmcraft version to support binary builds for 4.2