### PR TITLE
Add bases to the builder config

### DIFF
--- a/do-batch-with-cmd
+++ b/do-batch-with-cmd
@@ -14,6 +14,6 @@ for charm in $charms; do
     echo "Looking at: $charm"
     (
         cd $script_dir/charms/$charm
-        $target_cmd
+        $script_dir/$target_cmd
     )
 done

--- a/global/classic-zaza/build-requirements.txt
+++ b/global/classic-zaza/build-requirements.txt
@@ -5,3 +5,5 @@
 # * `tox -e build` successfully validated with charmcraft 1.2.1
 
 cffi==1.14.6; python_version < '3.6'  # cffi 1.15.0 drops support for py35.
+PyYAML
+six

--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -7,16 +7,25 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         - latest/edge
+      bases:
+        - "20.04"
+        - "22.04"
     stable/quincy.2:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - quincy/edge
+      bases:
+        - "20.04"
+        - "22.04"
     stable/quincy:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - quincy/stable
+      bases:
+        - "20.04"
+        - "22.04"
     stable/luminous:
       enabled: False
       build-channels:
@@ -25,6 +34,8 @@ defaults:
         #- openstack-queens/edge
         #- openstack-rocky/edge
         - luminous/edge
+      bases:
+        - "18.04"
     stable/mimic:
       enabled: False
       build-channels:
@@ -32,6 +43,8 @@ defaults:
       channels:
         #- openstack-stein/edge
         - mimic/edge
+      bases:
+        - "18.04"
     stable/nautilus:
       enabled: False
       build-channels:
@@ -39,18 +52,25 @@ defaults:
       channels:
         #- openstack-train/edge
         - nautilus/edge
+      bases:
+        - "18.04"
     stable/octopus:
       enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - octopus/edge
+      bases:
+        - "18.04"
+        - "20.04"
     stable/pacific:
       enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - pacific/stable
+      bases:
+        - "20.04"
 
 projects:
   - name: Ceph Dashboard Charm
@@ -63,28 +83,42 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
             - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/octopus:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
+      bases:
+        - "20.04"
 
   - name: Ceph FileSystem Charm
     charmhub: ceph-fs
@@ -101,16 +135,25 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/luminous:
         enabled: False
         build-channels:
@@ -119,6 +162,8 @@ projects:
           #- openstack-queens/edge
           #- openstack-rocky/edge
           - luminous/edge
+        bases:
+          - "18.04"
       stable/mimic:
         enabled: False
         build-channels:
@@ -126,6 +171,8 @@ projects:
         channels:
           #- openstack-stein/edge
           - mimic/edge
+        bases:
+          - "18.04"
       stable/nautilus:
         enabled: False
         build-channels:
@@ -133,18 +180,25 @@ projects:
         channels:
           #- openstack-train/edge
           - nautilus/edge
+        bases:
+          - "18.04"
       stable/octopus:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
+        bases:
+          - "20.04"
 
   - name: Ceph Monitor Charm
     charmhub: ceph-mon
@@ -156,16 +210,25 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/luminous:
         enabled: False
         build-channels:
@@ -174,6 +237,8 @@ projects:
           #- openstack-queens/edge
           #- openstack-rocky/edge
           - luminous/edge
+        bases:
+          - "18.04"
       stable/mimic:
         enabled: False
         build-channels:
@@ -181,6 +246,8 @@ projects:
         channels:
           #- openstack-stein/edge
           - mimic/edge
+        bases:
+          - "18.04"
       stable/nautilus:
         enabled: False
         build-channels:
@@ -188,18 +255,25 @@ projects:
         channels:
           #- openstack-train/edge
           - nautilus/edge
+        bases:
+          - "18.04"
       stable/octopus:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
+        bases:
+          - "20.04"
 
   - name: Ceph NFS Charm
     charmhub: ceph-nfs
@@ -211,22 +285,33 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/edge
+        bases:
+          - "20.04"
 
   - name: Ceph OSD Charm
     charmhub: ceph-osd
@@ -243,16 +328,25 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/luminous:
         enabled: False
         build-channels:
@@ -261,6 +355,8 @@ projects:
           #- openstack-queens/edge
           #- openstack-rocky/edge
           - luminous/edge
+        bases:
+          - "18.04"
       stable/mimic:
         enabled: False
         build-channels:
@@ -268,6 +364,8 @@ projects:
         channels:
           #- openstack-stein/edge
           - mimic/edge
+        bases:
+          - "18.04"
       stable/nautilus:
         enabled: False
         build-channels:
@@ -275,18 +373,25 @@ projects:
         channels:
           #- openstack-train/edge
           - nautilus/edge
+        bases:
+          - "18.04"
       stable/octopus:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
+        bases:
+          - "20.04"
 
   - name: Ceph Rados Gateway Charm
     charmhub: ceph-radosgw
@@ -298,16 +403,25 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy.2:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - quincy/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/quincy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/luminous:
         enabled: False
         build-channels:
@@ -316,6 +430,8 @@ projects:
           #- openstack-queens/edge
           #- openstack-rocky/edge
           - luminous/edge
+        bases:
+          - "18.04"
       stable/mimic:
         enabled: False
         build-channels:
@@ -323,6 +439,8 @@ projects:
         channels:
           #- openstack-stein/edge
           - mimic/edge
+        bases:
+          - "18.04"
       stable/nautilus:
         enabled: False
         build-channels:
@@ -330,18 +448,25 @@ projects:
         channels:
           #- openstack-train/edge
           - nautilus/edge
+        bases:
+          - "18.04"
       stable/octopus:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - octopus/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/pacific:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
+        bases:
+          - "20.04"
 
   - name: Ceph RBD Mirror Charm
     charmhub: ceph-rbd-mirror

--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -55,7 +55,6 @@ defaults:
       bases:
         - "18.04"
     stable/octopus:
-      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -64,7 +63,6 @@ defaults:
         - "18.04"
         - "20.04"
     stable/pacific:
-      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -103,7 +101,6 @@ projects:
           - "20.04"
           - "22.04"
       stable/octopus:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -112,13 +109,12 @@ projects:
           - "18.04"
           - "20.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - pacific/stable
-      bases:
-        - "20.04"
+        bases:
+          - "20.04"
 
   - name: Ceph FileSystem Charm
     charmhub: ceph-fs
@@ -183,7 +179,6 @@ projects:
         bases:
           - "18.04"
       stable/octopus:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -192,7 +187,6 @@ projects:
           - "18.04"
           - "20.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -258,7 +252,6 @@ projects:
         bases:
           - "18.04"
       stable/octopus:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -267,7 +260,6 @@ projects:
           - "18.04"
           - "20.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -305,11 +297,10 @@ projects:
           - "20.04"
           - "22.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - pacific/edge
+          - pacific/stable
         bases:
           - "20.04"
 
@@ -376,7 +367,6 @@ projects:
         bases:
           - "18.04"
       stable/octopus:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -385,7 +375,6 @@ projects:
           - "18.04"
           - "20.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -451,7 +440,6 @@ projects:
         bases:
           - "18.04"
       stable/octopus:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -460,7 +448,6 @@ projects:
           - "18.04"
           - "20.04"
       stable/pacific:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:

--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -14,11 +14,14 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - quincy/edge
+        - quincy/stable
       bases:
         - "20.04"
         - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
     stable/quincy:
+      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -58,7 +61,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - octopus/edge
+        - octopus/stable
       bases:
         - "18.04"
         - "20.04"
@@ -88,11 +91,14 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -104,7 +110,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - octopus/edge
+          - octopus/stable
         bases:
           - "18.04"
           - "20.04"
@@ -138,11 +144,14 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -182,7 +191,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - octopus/edge
+          - octopus/stable
         bases:
           - "18.04"
           - "20.04"
@@ -211,11 +220,14 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -255,7 +267,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - octopus/edge
+          - octopus/stable
         bases:
           - "18.04"
           - "20.04"
@@ -284,11 +296,14 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -326,11 +341,14 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -370,7 +388,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - octopus/edge
+          - octopus/stable
         bases:
           - "18.04"
           - "20.04"
@@ -399,11 +417,14 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - quincy/edge
+          - quincy/stable
         bases:
           - "20.04"
           - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
       stable/quincy:
+        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -443,7 +464,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - octopus/edge
+          - octopus/stable
         bases:
           - "18.04"
           - "20.04"

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -109,7 +109,6 @@ projects:
         bases:
           - "18.04"
       stable/5.7:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -143,7 +142,6 @@ projects:
       # focal
       #stable/3.8:
       stable/focal:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -238,11 +238,11 @@ projects:
           - "20.04"
           - "22.04"
       stable/focal:
-        enabled: False
+        enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - focal/edge
+          - focal/stable
         bases:
           - "20.04"
 
@@ -284,7 +284,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - focal/edge
+          - focal/stable
         bases:
           - "18.04"
           - "20.04"
@@ -293,7 +293,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - jammy/edge
+          - jammy/Stable
         bases:
           - "20.04"
           - "22.04"

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -10,7 +10,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
         bases:
@@ -33,7 +33,6 @@ projects:
           - "18.04"
           - "20.04"
       stable/bionic:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -48,7 +47,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.5/stable"
         channels:
           - latest/edge
 
@@ -59,7 +58,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
         bases:
@@ -103,7 +102,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
         bases:
@@ -123,7 +122,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
         bases:
@@ -151,7 +150,6 @@ projects:
           - "20.04"
       # bionic - not enabled yet
       stable/3.6:
-        enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -167,7 +165,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "1.7/stable"
         channels:
           - latest/edge
 
@@ -179,7 +177,7 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "2.0/stable"
+          charmcraft: "2.1/stable"
         channels:
           - latest/edge
         bases:
@@ -188,7 +186,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - 1.8/edge
+          - 1.8/stable
         bases:
           - "22.04"
       stable/1.7:
@@ -238,7 +236,6 @@ projects:
           - "20.04"
           - "22.04"
       stable/focal:
-        enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
@@ -293,7 +290,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - jammy/Stable
+          - jammy/stable
         bases:
           - "20.04"
           - "22.04"

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -13,22 +13,33 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 2.4/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/focal:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 2.0.3/stable
+        bases:
+          - "18.04"
+          - "20.04"
       stable/bionic:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 1.1.18/edge
+        bases:
+          - "18.04"
 
   - name: Magpie Charm
     charmhub: magpie
@@ -51,12 +62,17 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
       #stable/8.0:
       stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 8.0/stable
+        bases:
+          - "20.04"
+          - "22.04"
 
   - name: MySQL Router
     charmhub: mysql-router
@@ -68,12 +84,17 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
       #stable/8.0:
       stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 8.0/stable
+        bases:
+          - "20.04"
+          - "22.04"
 
   - name: Percona Cluster Charm
     charmhub: percona-cluster
@@ -85,12 +106,16 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
       stable/5.7:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 5.7/edge
+        bases:
+          - "18.04"
 
   - name: RabbitMQ Server Charm
     charmhub: rabbitmq-server
@@ -102,6 +127,9 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
       # jammy
       #stable/3.9:
       stable/jammy:
@@ -109,6 +137,9 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - 3.9/stable
+        bases:
+          - "20.04"
+          - "22.04"
       # focal
       #stable/3.8:
       stable/focal:
@@ -117,6 +148,9 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - 3.8/stable
+        bases:
+          - "18.04"
+          - "20.04"
       # bionic - not enabled yet
       stable/3.6:
         enabled: False
@@ -124,6 +158,8 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - 3.6/edge
+        bases:
+          - "18.04"
 
   - name: Woodpecker Charm
     # Note: woodpecker has not been promulgated
@@ -148,26 +184,39 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
       stable/1.8:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - 1.8/edge
+        bases:
+          - "22.04"
       stable/1.7:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 1.7/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/1.6:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 1.6/stable
+        bases:
+          - "18.04"
+          - "20.04"
       stable/1.5:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - 1.5/stable
+        bases:
+          - "18.04"
+          - "20.04"
 
   - name: OpenStack Loadbalancer Charm
     charmhub: openstack-loadbalancer
@@ -179,17 +228,25 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
+          - "22.10"
       stable/jammy:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - jammy/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/focal:
         enabled: False
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - focal/edge
+        bases:
+          - "20.04"
 
   - name: OpenID Connect Test Fixture Charm
     charmhub: openidc-test-fixture
@@ -213,21 +270,32 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
+          - "22.10"
       stable/bionic:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - bionic/edge
+        bases:
+          - "18.04"
       stable/focal:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - focal/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/jammy:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - jammy/edge
+        bases:
+          - "20.04"
+          - "22.04"

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -1213,7 +1213,7 @@ projects:
         channels:
           - victoria/stable
         bases:
-          - "18.04"
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
@@ -1221,7 +1221,7 @@ projects:
         channels:
           - wallaby/stable
         bases:
-          - "18.04"
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
@@ -1229,7 +1229,7 @@ projects:
         channels:
           - xena/stable
         bases:
-          - "18.04"
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -7,68 +7,80 @@ defaults:
         charmcraft: "2.0/stable"
       channels:
         - latest/edge
-    # Remove the queens, rocky and stein recipes at all those will be served
-    # from stable/train
-    #stable/queens:
-      #enabled: False
-      #build-channels:
-        #charmcraft: "1.5/stable"
-      #channels:
-        #- queens/edge
-    #stable/rocky:
-      #enabled: False
-      #build-channels:
-        #charmcraft: "1.5/stable"
-      #channels:
-        #- rocky/edge
-    #stable/stein:
-      #enabled: False
-      #build-channels:
-        #charmcraft: "1.5/stable"
-      #channels:
-        #- stein/edge
+      bases:
+        - "16.04"
+        - "18.04"
+        - "20.04"
+        - "22.04"
+        - "22.10"
     stable/train:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - train/edge
+        - stein/edge
+        - rock/edge
+        - queens/edge
+      bases:
+        - "18.04"
+      duplicate-channels:
+        # queens, rocky and stein recipes at all those will be served from
+        # stable/train
+        - queens
+        - rocky
+        - stein
     stable/ussuri:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - ussuri/edge
+      bases:
+        - "18.04"
+        - "20.04"
     stable/victoria:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - victoria/edge
+      bases:
+        - "20.04"
     stable/wallaby:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - wallaby/edge
+      bases:
+        - "20.04"
     stable/xena:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - xena/stable
+      bases:
+        - "20.04"
     stable/yoga:
       enabled: True
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - yoga/stable
+      bases:
+        - "20.04"
+        - "22.04"
     stable/zed:
       enabled: True
       build-channels:
         charmcraft: "2.0/stable"
       channels:
         - zed/edge
+      bases:
+        - "22.04"
+        - "22.10"
 
 projects:
   - name: OpenStack Aodh Charm
@@ -86,68 +98,78 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
-      # Remove the rocky and stein recipes at all those will be served
-      # from stable/train
-      #stable/rocky:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- rocky/edge
-      #stable/stein:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- stein/edge
+        bases:
+          - "16.04"
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+          - stein/edge
+          - rocky/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # rocky and stein recipes at all those will be served from
+          # stable/train
+          - rocky
+          - stein
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
-
-  # disabled as no longer supported
-  # - name: OpenStack Barbican SoftHSM Charm
-  #  charmhub: barbican-softhsm
-  #  launchpad: charm-barbican-softhsm
-  #  repository: https://opendev.org/openstack/charm-barbican-softhsm.git
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Barbican Vault Charm
     charmhub: barbican-vault
@@ -160,59 +182,77 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
-      #stable/rocky:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- rocky/edge
-      #stable/stein:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- stein/edge
+        bases:
+          - "16.04"
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+          - stein/edge
+          - rocky/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # rocky and stein recipes at all those will be served from
+          # stable/train
+          - rocky
+          - stein
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Ceilometer Charm
     charmhub: ceilometer
@@ -309,26 +349,10 @@ projects:
     launchpad: charm-masakari-monitors
     repository: https://opendev.org/openstack/charm-masakari-monitors.git
 
-#  - name: OpenStack Mistral Charm
-#    charmhub: mistral
-#    launchpad: charm-mistral
-#    repository: https://opendev.org/openstack/charm-mistral.git
-#
-#  - name: OpenStack Murano Charm
-#    charmhub: murano
-#    launchpad: charm-murano
-#    repository: https://opendev.org/openstack/charm-murano.git
-
   - name: OpenStack Neutron API Charm
     charmhub: neutron-api
     launchpad: charm-neutron-api
     repository: https://opendev.org/openstack/charm-neutron-api.git
-
-  # disabled as no longer supported.
-  # - name: OpenStack Neutron API Open Daylight Charm
-  #  charmhub: neutron-api-odl
-  #  launchpad: charm-neutron-api-odl
-  #  repository: https://opendev.org/openstack/charm-neutron-api-odl.git
 
   - name: OpenStack Neutron Gateway Charm
     charmhub: neutron-gateway
@@ -375,62 +399,77 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
-      # Remove the rocky and stein recipes at all those will be served
-      # from stable/train
-      #stable/rocky:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- rocky/edge
-      #stable/stein:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- stein/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+          - stein/edge
+          - rocky/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # rocky and stein recipes at all those will be served from
+          # stable/train
+          - rocky
+          - stein
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Placement charm
     charmhub: placement
@@ -443,12 +482,19 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+        bases:
+          - "18.04"
       stable/ussuri:
         enabled: True
         build-channels:
@@ -461,45 +507,43 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
-
-#  - name: OpenStack Tempest Charm
-#    charmhub: tempest
-#    launchpad: charm-tempest
-#    repository: https://opendev.org/openstack/charm-tempest.git
-#
-#  - name: OpenStack Trove Charm
-#    charmhub: trove
-#    launchpad: charm-trove
-#    repository: https://opendev.org/openstack/charm-trove.git
-
-#  - name: OpenStack Panko Charm
-#    charmhub: panko
-#    launchpad: charm-panko
-#    repository: https://opendev.org/openstack/charm-panko.git
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Swift Proxy Charm
     charmhub: swift-proxy
@@ -546,42 +590,60 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Cinder Purestorage Charm
     charmhub: cinder-purestorage
@@ -594,48 +656,70 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - ussuri/edge
+          - train/edge
+        bases:
+          - "18.04"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - xena/edge
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Cinder Solidfire Charm
     charmhub: cinder-solidfire
@@ -648,42 +732,60 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Cinder NetApp Charm
     charmhub: cinder-netapp
@@ -701,42 +803,60 @@ projects:
           charmcraft: "1.7/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Ironic API Charm
     charmhub: ironic-api
@@ -749,48 +869,70 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+        bases:
+          - "18.04"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Ironic Conductor Charm
     charmhub: ironic-conductor
@@ -803,48 +945,70 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+        bases:
+          - "18.04"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Keystone Kerberos Charm
     charmhub: keystone-kerberos
@@ -862,12 +1026,18 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "22.04"
+          - "22.10"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Keystone SAML Mellon Charm
     charmhub: keystone-saml-mellon
@@ -885,42 +1055,60 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Magnum Dashboard Charm
     charmhub: magnum-dashboard
@@ -933,42 +1121,60 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Manila Dashboard Charm
     charmhub: manila-dashboard
@@ -979,6 +1185,67 @@ projects:
     charmhub: manila-netapp
     launchpad: charm-manila-netapp
     repository: https://opendev.org/openstack/charm-manila-netapp.git
+    branches:
+      master:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
+      stable/ussuri:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - ussuri/edge
+        bases:
+          - "20.04"
+      stable/victoria:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - victoria/edge
+        bases:
+          - "18.04"
+      stable/wallaby:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - wallaby/edge
+        bases:
+          - "18.04"
+      stable/xena:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - xena/stable
+        bases:
+          - "18.04"
+      stable/yoga:
+        enabled: True
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/zed:
+        enabled: True
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Neutron API Arista Plugin charm
     charmhub: neutron-api-plugin-arista
@@ -996,48 +1263,70 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+        bases:
+          - "18.04"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Neutron API OVN Plugin Charm
     charmhub: neutron-api-plugin-ovn
@@ -1050,42 +1339,60 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   # - name: OpenStack Neutron Dynamic Routing Charm
   #  charmhub: neutron-dynamic-routing
@@ -1102,62 +1409,77 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
-      # Remove the rocky and stein recipes at all those will be served
-      # from stable/train
-      #stable/rocky:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- rocky/edge
-      #stable/stein:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- stein/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+          - stein/edge
+          - rocky/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # rocky and stein recipes at all those will be served from
+          # stable/train
+          - rocky
+          - stein
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"
 
   - name: OpenStack Octavia Disk-Image Retrofit Charm
     charmhub: octavia-diskimage-retrofit
@@ -1169,59 +1491,74 @@ projects:
           charmcraft: "2.0/stable"
         channels:
           - latest/edge
-      # Remove the rocky and stein recipes at all those will be served
-      # from stable/train
-      #stable/rocky:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- rocky/edge
-      #stable/stein:
-        #enabled: False
-        #build-channels:
-          #charmcraft: "1.5/stable"
-        #channels:
-          #- stein/edge
+        bases:
+          - "18.04"
+          - "20.04"
+          - "22.04"
+          - "22.10"
       stable/train:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - train/edge
+          - stein/edge
+          - rocky/edge
+        bases:
+          - "18.04"
+        duplicate-channels:
+          # rocky and stein recipes at all those will be served from
+          # stable/train
+          - rocky
+          - stein
       stable/ussuri:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - victoria/edge
+        bases:
+          - "20.04"
       stable/wallaby:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - wallaby/edge
+        bases:
+          - "20.04"
       stable/xena:
         enabled: True
         build-channels:
           charmcraft: "1.5/stable"
         channels:
           - xena/stable
+        bases:
+          - "20.04"
       stable/yoga:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - yoga/stable
+        bases:
+          - "20.04"
+          - "22.04"
       stable/zed:
         enabled: True
         build-channels:
           charmcraft: "2.0/stable"
         channels:
           - zed/edge
+        bases:
+          - "22.04"
+          - "22.10"

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -20,7 +20,7 @@ defaults:
       channels:
         - train/edge
         - stein/edge
-        - rock/edge
+        - rocky/edge
         - queens/edge
       bases:
         - "18.04"
@@ -501,6 +501,9 @@ projects:
           charmcraft: "1.5/stable"
         channels:
           - ussuri/edge
+        bases:
+          - "18.04"
+          - "20.04"
       stable/victoria:
         enabled: True
         build-channels:
@@ -508,7 +511,6 @@ projects:
         channels:
           - victoria/edge
         bases:
-          - "18.04"
           - "20.04"
       stable/wallaby:
         enabled: True

--- a/lp-builder-config/openstack.yaml
+++ b/lp-builder-config/openstack.yaml
@@ -35,7 +35,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - ussuri/edge
+        - ussuri/stable
       bases:
         - "18.04"
         - "20.04"
@@ -44,7 +44,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - victoria/edge
+        - victoria/stable
       bases:
         - "20.04"
     stable/wallaby:
@@ -52,7 +52,7 @@ defaults:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
-        - wallaby/edge
+        - wallaby/stable
       bases:
         - "20.04"
     stable/xena:
@@ -77,7 +77,7 @@ defaults:
       build-channels:
         charmcraft: "2.0/stable"
       channels:
-        - zed/edge
+        - zed/stable
       bases:
         - "22.04"
         - "22.10"
@@ -124,7 +124,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -133,7 +133,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -141,7 +141,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -166,7 +166,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -208,7 +208,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -217,7 +217,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -225,7 +225,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -249,7 +249,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -424,7 +424,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -433,7 +433,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -441,7 +441,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -466,7 +466,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -500,7 +500,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -509,7 +509,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -517,7 +517,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -542,7 +542,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -601,7 +601,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -609,7 +609,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -617,7 +617,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -642,7 +642,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -676,7 +676,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -685,7 +685,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -693,7 +693,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -718,7 +718,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -743,7 +743,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -751,7 +751,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -759,7 +759,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -784,7 +784,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -814,7 +814,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -822,7 +822,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -830,7 +830,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -855,7 +855,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -889,7 +889,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -898,7 +898,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -906,7 +906,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -931,7 +931,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -965,7 +965,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -974,7 +974,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -982,7 +982,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1007,7 +1007,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1036,7 +1036,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1066,7 +1066,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -1074,7 +1074,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1082,7 +1082,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1107,7 +1107,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1132,7 +1132,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -1140,7 +1140,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1148,7 +1148,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1173,7 +1173,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1203,7 +1203,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -1211,7 +1211,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "18.04"
       stable/wallaby:
@@ -1219,7 +1219,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "18.04"
       stable/xena:
@@ -1244,7 +1244,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1283,7 +1283,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -1292,7 +1292,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1300,7 +1300,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1325,7 +1325,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1350,7 +1350,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "20.04"
       stable/victoria:
@@ -1358,7 +1358,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1366,7 +1366,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1391,7 +1391,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1436,7 +1436,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -1445,7 +1445,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1453,7 +1453,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1478,7 +1478,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"
@@ -1518,7 +1518,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - ussuri/edge
+          - ussuri/stable
         bases:
           - "18.04"
           - "20.04"
@@ -1527,7 +1527,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - victoria/edge
+          - victoria/stable
         bases:
           - "20.04"
       stable/wallaby:
@@ -1535,7 +1535,7 @@ projects:
         build-channels:
           charmcraft: "1.5/stable"
         channels:
-          - wallaby/edge
+          - wallaby/stable
         bases:
           - "20.04"
       stable/xena:
@@ -1560,7 +1560,7 @@ projects:
         build-channels:
           charmcraft: "2.0/stable"
         channels:
-          - zed/edge
+          - zed/stable
         bases:
           - "22.04"
           - "22.10"

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -4,7 +4,7 @@ defaults:
   branches:
     master:
       build-channels:
-        charmcraft: "2.0/stable"
+        charmcraft: "2.1/stable"
       channels:
         - latest/edge
       bases:

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -16,7 +16,7 @@ defaults:
       channels:
         #- openstack-ussuri/edge
         #- openstack-victoria/edge
-        - 20.03/edge
+        - 20.03/stable
       bases:
         - "18.04"
         - "20.04"
@@ -25,7 +25,7 @@ defaults:
         charmcraft: "1.5/stable"
       channels:
         #- openstack-wallaby/edge
-        - 20.12/edge
+        - 20.12/stable
       bases:
         - "20.04"
     stable/21.09:
@@ -48,7 +48,7 @@ defaults:
       build-channels:
         charmcraft: "2.1/stable"
       channels:
-        - 22.09/edge
+        - 22.09/stable
       bases:
         - "22.04"
         - "22.10"

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -7,6 +7,9 @@ defaults:
         charmcraft: "2.0/stable"
       channels:
         - latest/edge
+      bases:
+        - "22.04"
+        - "22.10"
     stable/20.03:
       enabled: False
       build-channels:
@@ -15,6 +18,9 @@ defaults:
         #- openstack-ussuri/edge
         #- openstack-victoria/edge
         - 20.03/edge
+      bases:
+        - "18.04"
+        - "20.04"
     stable/20.12:
       enabled: False
       build-channels:
@@ -22,6 +28,8 @@ defaults:
       channels:
         #- openstack-wallaby/edge
         - 20.12/edge
+      bases:
+        - "20.04"
     stable/21.09:
       enabled: False
       build-channels:
@@ -29,16 +37,24 @@ defaults:
       channels:
         #- openstack-xena/edge
         - 21.09/stable
+      bases:
+        - "20.04"
     stable/22.03:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - 22.03/stable
+      bases:
+        - "20.04"
+        - "22.04"
     stable/22.09:
       build-channels:
         charmcraft: "2.1/stable"
       channels:
-        - 22.09/stable
+        - 22.09/edge
+      bases:
+        - "22.04"
+        - "22.10"
 
 projects:
   - name: OVN Central

--- a/lp-builder-config/ovn.yaml
+++ b/lp-builder-config/ovn.yaml
@@ -11,7 +11,6 @@ defaults:
         - "22.04"
         - "22.10"
     stable/20.03:
-      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -22,7 +21,6 @@ defaults:
         - "18.04"
         - "20.04"
     stable/20.12:
-      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:
@@ -31,7 +29,6 @@ defaults:
       bases:
         - "20.04"
     stable/21.09:
-      enabled: False
       build-channels:
         charmcraft: "1.5/stable"
       channels:

--- a/lp-builder-config/trilio.yaml
+++ b/lp-builder-config/trilio.yaml
@@ -7,21 +7,33 @@ defaults:
         charmcraft: "2.0/stable"
       channels:
         - latest/edge
+      bases:
+        - "18.04"
+        - "20.04"
     stable/4.0:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - 4.0/stable
+      bases:
+        - "20.04"
+        - "22.04"
     stable/4.1:
       build-channels:
         charmcraft: "1.5/stable"
       channels:
         - 4.1/stable
+      bases:
+        - "20.04"
+        - "22.04"
     stable/4.2:
       build-channels:
         charmcraft: "2.0/stable"
       channels:
         - 4.2/stable
+      bases:
+        - "18.04"
+        - "20.04"
 
 projects:
   - name: Trilio Data Mover


### PR DESCRIPTION
This addition enables the charmhub-lp-tools command to read the config and apply the bases automatically for channels.  This information is separate from the charmcraft.yaml as channels can contain charms from different eras and it's important that they are maintained.