### PR TITLE
change tox package version to use < 4.0

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -23,6 +23,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires =
+  tox < 4.0
   pip < 20.3
   virtualenv < 20.0
   setuptools < 50.0.0

--- a/global/source-zaza/src/tox.ini
+++ b/global/source-zaza/src/tox.ini
@@ -21,6 +21,7 @@ skip_missing_interpreters = False
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
            virtualenv < 20.0
+           tox < 4.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.18.0
 

--- a/global/source-zaza/tox.ini
+++ b/global/source-zaza/tox.ini
@@ -20,6 +20,7 @@ skip_missing_interpreters = False
 #   lead to fetching the latest pip in the func* tox targets, see
 #   https://stackoverflow.com/a/38133283
 requires =
+  tox < 4.0
   pip < 20.3
   virtualenv < 20.0
   setuptools<50.0.0


### PR DESCRIPTION
With the latest tox version 4.x, tox commands
fail with the following error message:
ModuleNotFoundError: No module named 'virtualenv.discovery'; 'virtualenv' is not a package

To avoid this pin tox version to < 4.0