### PR TITLE
Misc/ceph lp-builder-config updates for 22.10

### DIFF
--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -126,6 +126,78 @@ projects:
     charmhub: ceph-fs
     launchpad: charm-ceph-fs
     repository: https://opendev.org/openstack/charm-ceph-fs.git
+    branches:
+      master:
+        build-channels:
+          charmcraft: "2.0/stable"
+        channels:
+          - latest/edge
+        bases:
+          - "20.04"
+          - "22.04"
+          - "22.10"
+    stable/quincy.2:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - quincy/stable
+      bases:
+        - "20.04"
+        - "22.04"
+    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+    # "quincy" branch.
+    stable/quincy:
+      enabled: False
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - quincy/stable
+      bases:
+        - "20.04"
+        - "22.04"
+    stable/luminous:
+      enabled: False
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        #- openstack-queens/edge
+        #- openstack-rocky/edge
+        - luminous/edge
+      bases:
+        - "18.04"
+    stable/mimic:
+      enabled: False
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        #- openstack-stein/edge
+        - mimic/edge
+      bases:
+        - "18.04"
+    stable/nautilus:
+      enabled: False
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        #- openstack-train/edge
+        - nautilus/edge
+      bases:
+        - "18.04"
+    stable/octopus:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - octopus/stable
+      bases:
+        - "18.04"
+        - "20.04"
+    stable/pacific:
+      build-channels:
+        charmcraft: "1.5/stable"
+      channels:
+        - pacific/stable
+      bases:
+        - "20.04"
 
   - name: Ceph iSCSI Charm
     charmhub: ceph-iscsi
@@ -216,6 +288,7 @@ projects:
         bases:
           - "20.04"
           - "22.04"
+          - "22.10"
       stable/quincy.2:
         build-channels:
           charmcraft: "2.0/stable"

--- a/lp-builder-config/ceph.yaml
+++ b/lp-builder-config/ceph.yaml
@@ -136,68 +136,68 @@ projects:
           - "20.04"
           - "22.04"
           - "22.10"
-    stable/quincy.2:
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        - quincy/stable
-      bases:
-        - "20.04"
-        - "22.04"
-    # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
-    # "quincy" branch.
-    stable/quincy:
-      enabled: False
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        - quincy/stable
-      bases:
-        - "20.04"
-        - "22.04"
-    stable/luminous:
-      enabled: False
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        #- openstack-queens/edge
-        #- openstack-rocky/edge
-        - luminous/edge
-      bases:
-        - "18.04"
-    stable/mimic:
-      enabled: False
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        #- openstack-stein/edge
-        - mimic/edge
-      bases:
-        - "18.04"
-    stable/nautilus:
-      enabled: False
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        #- openstack-train/edge
-        - nautilus/edge
-      bases:
-        - "18.04"
-    stable/octopus:
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        - octopus/stable
-      bases:
-        - "18.04"
-        - "20.04"
-    stable/pacific:
-      build-channels:
-        charmcraft: "1.5/stable"
-      channels:
-        - pacific/stable
-      bases:
-        - "20.04"
+      stable/quincy.2:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      # stable/quincy is deprecated in favour of stable/quincy.2 which is now the
+      # "quincy" branch.
+      stable/quincy:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - quincy/stable
+        bases:
+          - "20.04"
+          - "22.04"
+      stable/luminous:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          #- openstack-queens/edge
+          #- openstack-rocky/edge
+          - luminous/edge
+        bases:
+          - "18.04"
+      stable/mimic:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          #- openstack-stein/edge
+          - mimic/edge
+        bases:
+          - "18.04"
+      stable/nautilus:
+        enabled: False
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          #- openstack-train/edge
+          - nautilus/edge
+        bases:
+          - "18.04"
+      stable/octopus:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - octopus/stable
+        bases:
+          - "18.04"
+          - "20.04"
+      stable/pacific:
+        build-channels:
+          charmcraft: "1.5/stable"
+        channels:
+          - pacific/stable
+        bases:
+          - "20.04"
 
   - name: Ceph iSCSI Charm
     charmhub: ceph-iscsi

--- a/lp-builder-config/misc.yaml
+++ b/lp-builder-config/misc.yaml
@@ -63,6 +63,7 @@ projects:
           - latest/edge
         bases:
           - "22.04"
+          - "22.10"
       #stable/8.0:
       stable/jammy:
         build-channels:
@@ -80,11 +81,12 @@ projects:
     branches:
       master:
         build-channels:
-          charmcraft: "1.5/stable"
+          charmcraft: "2.0/stable"
         channels:
           - latest/edge
         bases:
           - "22.04"
+          - "22.10"
       #stable/8.0:
       stable/jammy:
         build-channels:
@@ -128,6 +130,7 @@ projects:
         bases:
           - "20.04"
           - "22.04"
+          - "22.10"
       # jammy
       #stable/3.9:
       stable/jammy:
@@ -182,6 +185,7 @@ projects:
           - latest/edge
         bases:
           - "22.04"
+          - "22.10"
       stable/1.8:
         build-channels:
           charmcraft: "2.0/stable"


### PR DESCRIPTION
These updates correspond to updates made in this topic: https://review.opendev.org/q/topic:kinetic-support

I did not update ceph-osd because it already built successfully and is published to latest/edge for 22.10.