### PR TITLE
Treat fetch of master or main as alias'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 ruamel.yaml
 theblues
 libcharmstore
-#git+https://github.com/openstack-charmers/charmed-openstack-info.git#egg=charmed-openstack-info
--e /home/alex/Projects/Canonical/git/github.com/openstack-charmers/charmed-openstack-info
+git+https://github.com/openstack-charmers/charmed-openstack-info.git#egg=charmed-openstack-info
 GitPython
 humanize
 launchpadlib


### PR DESCRIPTION
We have a mix of charm repositories with master and main branches. Therefore 'fetch-charms.py --branch master' will fail for some git repos and 'fetch-charms.py --branch main' will do the same.

This change updates fetch-charms.py to treat master and main as alias'. If fetching master fails for a project, try to fetch main. And if fetching main fails for a project, try to fetch master.