### PR TITLE
Drop `--` from commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,22 +25,22 @@ commands = flake8 {posargs} .
 [testenv:revisions]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
-commands = python3 {toxinidir}/list-revisions-in-charmstore.py -- {posargs}
+commands = python3 {toxinidir}/list-revisions-in-charmstore.py {posargs}
 
 [testenv:code-imports-status]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
-commands = python3 {toxinidir}/code-imports-status.py -- {posargs}
+commands = python3 {toxinidir}/code-imports-status.py {posargs}
 
 [testenv:fetch-charms]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
-commands = python3 {toxinidir}/fetch-charms.py -- {posargs}
+commands = python3 {toxinidir}/fetch-charms.py {posargs}
 
 [testenv:update-channel-single]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
-commands = python3 {toxinidir}/update-channel-single.py -- {posargs}
+commands = python3 {toxinidir}/update-channel-single.py {posargs}
 
 [flake8]
 ignore = E402,E226,W504


### PR DESCRIPTION
The double dash breaks the execution of the python scripts when passing arguments.