### PR TITLE
Add `release-contributors` tox target

### DIFF
--- a/fetch-charms.py
+++ b/fetch-charms.py
@@ -334,14 +334,14 @@ def main() -> None:
             reuse=args.reuse,
         )
     except AssertionError as e:
-        branch = master_main_swap(branch)
+        branch = master_main_swap(args.branch)
         if branch:
             try:
                 fetch_charms(
                     charms=charms,
                     where=directory,
                     replace=args.replace,
-                    branch=args.branch,
+                    branch=branch,
                     worktrees=args.worktrees,
                     worktree_dir=args.worktree_dir,
                     ignore_failure=args.ignore_failure,

--- a/release-contributors.sh
+++ b/release-contributors.sh
@@ -94,7 +94,11 @@ for GROUP in "${!BASELINE_BRANCHES[@]}"; do
 
   for DIR in ${CHARMS_DIR}/${GROUP}/*/; do
     log "Processing charm ${DIR}..."
-    git -C $DIR log --format="%an" origin/stable/"${BASELINE_BRANCHES[$GROUP]}"..${LAST_REF} 2>/dev/null >> $ALL_CONTRIBUTORS_FILE
+    if  $(git -C $DIR branch -r | grep -q origin/stable/"${BASELINE_BRANCHES[$GROUP]}"); then
+      git -C $DIR log --format="%an" origin/stable/"${BASELINE_BRANCHES[$GROUP]}"..${LAST_REF} 2>/dev/null >> $ALL_CONTRIBUTORS_FILE
+    else
+      echo Repo $DIR does not have branch origin/stable/"${BASELINE_BRANCHES[$GROUP]}", skipping
+    fi
   done
 done
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,13 @@ basepython = python3
 deps = -r{toxinidir}/requirements.txt
 commands = python3 {toxinidir}/fetch-charms.py {posargs}
 
+[testenv:release-contributors]
+basepython = python3
+deps = -r{toxinidir}/requirements.txt
+allowlist_externals =
+    {toxinidir}/release-contributors.sh
+commands = {toxinidir}/release-contributors.sh {posargs}
+
 [testenv:update-channel-single]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This new target runs release-contributors.sh, but more importantly is that enables an environment where fetch-charms.py can run successfully