### PR TITLE
Remove py311 target (for 2023.2) updates.

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -57,7 +57,7 @@ deps = -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3

--- a/global/ops-zaza/tox.ini
+++ b/global/ops-zaza/tox.ini
@@ -52,7 +52,7 @@ deps = -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3

--- a/global/source-zaza/tox-binary-wheels.ini
+++ b/global/source-zaza/tox-binary-wheels.ini
@@ -50,17 +50,17 @@ commands =
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps = -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]

--- a/global/source-zaza/tox-source-wheels.ini
+++ b/global/source-zaza/tox-source-wheels.ini
@@ -52,17 +52,17 @@ commands =
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps = -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps = -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]

--- a/lock-with-pip-compile
+++ b/lock-with-pip-compile
@@ -171,6 +171,8 @@ function lock_with_pip_compile_reactive {
     do_merged_pip_compile python3.8 py38 requirements.in test-requirements.in
     do_merged_pip_compile python3.10 py310 requirements.in test-requirements.in
     do_pip_compile python3.8 src/test-requirements.in src/test-requirements-py38.txt
+    do_pip_compile python3.8 test-requirements.in test-requirements-py38.txt
+    do_pip_compile python3.10 test-requirements.in test-requirements-py310.txt
 }
 
 
@@ -192,6 +194,7 @@ function lock_with_pip_compile_ops_machine {
 # install venvs for python3.8 and python3.10 for the pip-compile
 install_venv python3.8
 install_venv python3.10
+install_venv python3.11
 
 
 case $charm_type in


### PR DESCRIPTION
This will be re-instated for the master/main branches after the 2023.2
release is done.
