### PR TITLE
Add constraints to tox.ini files under global/**

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -32,7 +32,10 @@ passenv =
     CS_*
     OS_*
     TEST_*
-deps = -r{toxinidir}/test-requirements-py38.txt
+    TOX_CONSTRAINTS_FILE
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py38.txt
 
 [testenv:build]
 basepython = python3
@@ -49,20 +52,28 @@ commands =
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
-       git+https://github.com/juju/charm-tools.git
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    flake8==3.9.2
+    git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
            charm-proof
 
@@ -70,7 +81,9 @@ commands = flake8 {posargs} hooks unit_tests tests actions lib files
 # Technique based heavily upon
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run

--- a/global/ops-zaza/tox.ini
+++ b/global/ops-zaza/tox.ini
@@ -40,30 +40,43 @@ passenv =
     CS_*
     OS_*
     TEST_*
-deps = -r{toxinidir}/merged-requirements-py38.txt
+    TOX_CONSTRAINTS_FILE
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/merged-requirements-py38.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    flake8==3.9.2
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
 
 [testenv:cover]
 # Technique based heavily upon
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run

--- a/global/source-zaza/tox-binary-wheels.ini
+++ b/global/source-zaza/tox-binary-wheels.ini
@@ -29,11 +29,13 @@ passenv =
     CHARM_INTERFACES_DIR
     CHARM_LAYERS_DIR
     JUJU_REPOSITORY
+    TOX_CONSTRAINTS_FILE
 allowlist_externals =
     charmcraft
     bash
     tox
 deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:build]
@@ -50,29 +52,39 @@ commands =
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/test-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/test-requirements-py38.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/test-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    flake8==3.9.2
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]
 # Technique based heavily upon
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run

--- a/global/source-zaza/tox-source-wheels.ini
+++ b/global/source-zaza/tox-source-wheels.ini
@@ -29,12 +29,14 @@ passenv =
     CHARM_INTERFACES_DIR
     CHARM_LAYERS_DIR
     JUJU_REPOSITORY
+    TOX_CONSTRAINTS_FILE
 allowlist_externals =
     charmcraft
     bash
     tox
     {toxinidir}/rename.sh
 deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:build]
@@ -52,29 +54,39 @@ commands =
 
 [testenv:py3]
 basepython = python3
-deps = -r{toxinidir}/test-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
-deps = -r{toxinidir}/test-requirements-py38.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
-deps = -r{toxinidir}/test-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]
 basepython = python3
-deps = flake8==3.9.2
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    flake8==3.9.2
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]
 # Technique based heavily upon
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
-deps = -r{toxinidir}/merged-requirements-py310.txt
+deps =
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}
     PYTHON=coverage run


### PR DESCRIPTION
The constraints file allows globally pinning the versions used by the tox testing environments and posibly override this by zosci[0]

[0] https://github.com/openstack-charmers/zosci-config/pull/324

Depends-On: https://github.com/openstack-charmers/zaza-openstack-tests/pull/1184