### PR TITLE
Rename TOX_CONSTRAINTS_FILE to TEST_CONSTRAINTS_FILE

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -32,9 +32,8 @@ passenv =
     CS_*
     OS_*
     TEST_*
-    TOX_CONSTRAINTS_FILE
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py38.txt
 
 [testenv:build]
@@ -53,25 +52,25 @@ commands =
 [testenv:py38]
 basepython = python3.8
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py310]
 basepython = python3.10
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     flake8==3.9.2
     git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
@@ -82,7 +81,7 @@ commands = flake8 {posargs} hooks unit_tests tests actions lib files
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
 deps =
-    -c {env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}

--- a/global/ops-zaza/tox.ini
+++ b/global/ops-zaza/tox.ini
@@ -40,33 +40,32 @@ passenv =
     CS_*
     OS_*
     TEST_*
-    TOX_CONSTRAINTS_FILE
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py38]
 basepython = python3.8
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:py310]
 basepython = python3.10
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:py3]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 
 [testenv:pep8]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     flake8==3.9.2
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
 
@@ -75,7 +74,7 @@ commands = flake8 {posargs} hooks unit_tests tests actions lib files
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}

--- a/global/source-zaza/tox-binary-wheels.ini
+++ b/global/source-zaza/tox-binary-wheels.ini
@@ -29,13 +29,13 @@ passenv =
     CHARM_INTERFACES_DIR
     CHARM_LAYERS_DIR
     JUJU_REPOSITORY
-    TOX_CONSTRAINTS_FILE
+    TEST_*
 allowlist_externals =
     charmcraft
     bash
     tox
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:build]
@@ -53,28 +53,28 @@ commands =
 [testenv:py3]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     flake8==3.9.2
 commands = flake8 {posargs} src unit_tests
 
@@ -83,7 +83,7 @@ commands = flake8 {posargs} src unit_tests
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}

--- a/global/source-zaza/tox-source-wheels.ini
+++ b/global/source-zaza/tox-source-wheels.ini
@@ -29,14 +29,14 @@ passenv =
     CHARM_INTERFACES_DIR
     CHARM_LAYERS_DIR
     JUJU_REPOSITORY
-    TOX_CONSTRAINTS_FILE
+    TEST_*
 allowlist_externals =
     charmcraft
     bash
     tox
     {toxinidir}/rename.sh
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py38.txt
 
 [testenv:build]
@@ -55,28 +55,28 @@ commands =
 [testenv:py3]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py38]
 basepython = python3.8
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py38.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:py310]
 basepython = python3.10
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/test-requirements-py310.txt
 commands = stestr run --slowest {posargs}
 
 [testenv:pep8]
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     flake8==3.9.2
 commands = flake8 {posargs} src unit_tests
 
@@ -85,7 +85,7 @@ commands = flake8 {posargs} src unit_tests
 # https://github.com/openstack/nova/blob/master/tox.ini
 basepython = python3
 deps =
-    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
+    -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     -r{toxinidir}/merged-requirements-py310.txt
 setenv =
     {[testenv]setenv}


### PR DESCRIPTION
The environment variable TOX_CONSTRAINTS_FILE is used by upstream zuul to pass OpenStack's global upper constraints, when (re)using this environment variable the unitended consequence is that running CI jobs in upstream's zuul makes the charm to use the wrong constraints file.