### PR TITLE
Bump up flake8 to 7.1.1

### DIFF
--- a/global/classic-zaza/tox.ini
+++ b/global/classic-zaza/tox.ini
@@ -71,7 +71,7 @@ deps =
 basepython = python3
 deps =
     -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
-    flake8==3.9.2
+    flake8==7.1.1
     git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
            charm-proof

--- a/global/ops-zaza/tox.ini
+++ b/global/ops-zaza/tox.ini
@@ -66,7 +66,7 @@ deps =
 basepython = python3
 deps =
     -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
-    flake8==3.9.2
+    flake8==7.1.1
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
 
 [testenv:cover]

--- a/global/source-zaza/tox-binary-wheels.ini
+++ b/global/source-zaza/tox-binary-wheels.ini
@@ -75,7 +75,7 @@ commands = stestr run --slowest {posargs}
 basepython = python3
 deps =
     -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
-    flake8==3.9.2
+    flake8==7.1.1
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]

--- a/global/source-zaza/tox-source-wheels.ini
+++ b/global/source-zaza/tox-source-wheels.ini
@@ -77,7 +77,7 @@ commands = stestr run --slowest {posargs}
 basepython = python3
 deps =
     -c{env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
-    flake8==3.9.2
+    flake8==7.1.1
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]


### PR DESCRIPTION
flake8-3.9.2 doesn't run on py312 due to a breaking change in importlib, this change bumps up the pin to 7.1.1 the latest release at the moment.

Related-Pr: https://github.com/python/importlib_metadata/issues/409