### PR TITLE
Remove setuptools pin in requirements.txt

### DIFF
--- a/global/source-zaza/requirements.in
+++ b/global/source-zaza/requirements.in
@@ -2,11 +2,6 @@
 # within individual charm repos.  See the 'global' dir contents for available
 # choices of *requirements.txt files for OpenStack Charms:
 #     https://github.com/openstack-charmers/release-tools
-#
-# NOTE(lourot): This might look like a duplication of test-requirements.txt but
-# some tox targets use only test-requirements.txt whereas charm-build uses only
-# requirements.txt
-setuptools<50.0.0  # https://github.com/pypa/setuptools/commit/04e3df22df840c6bb244e9b27bc56750c44b7c85
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see


### PR DESCRIPTION
The <50.0 pinned version of setuptools tries to use an older version of pkg_resources, which causes conflict with the 'six' package.